### PR TITLE
Add @:coroutine.transformed

### DIFF
--- a/src-json/meta.json
+++ b/src-json/meta.json
@@ -149,6 +149,12 @@
 		"targets": ["TClassField"]
 	},
 	{
+		"name": "CoroutineTransformed",
+		"metadata": ":coroutine.transformed",
+		"doc": "Marks a field as being a coroutine that has already been transformed",
+		"targets": ["TClassField"]
+	},
+	{
 		"name": "CppFileCode",
 		"metadata": ":cppFileCode",
 		"doc": "Code to be injected into generated cpp file.",

--- a/src/coro/coroDebug.ml
+++ b/src/coro/coroDebug.ml
@@ -31,8 +31,6 @@ let create_dotgraph path cb =
 				Some "continue"
 			| NextReturnVoid ->
 				Some "return"
-			| NextExit ->
-				Some "exit"
 			| NextReturn e ->
 				Some ("return " ^ se e)
 			| NextThrow e ->

--- a/src/coro/coroFromTexpr.ml
+++ b/src/coro/coroFromTexpr.ml
@@ -170,9 +170,6 @@ let expr_to_coro ctx eresult cb_root e =
 			let cb_ret,e1 = loop_assign cb ret e1 in
 			terminate cb_ret (NextReturn e1) e.etype e.epos;
 			ctx.cb_unreachable,e_no_value
-		| TThrow {eexpr = TReturn None} ->
-			terminate cb NextExit e.etype e.epos;
-			ctx.cb_unreachable,e_no_value
 		| TThrow e1 ->
 			let f_terminate cb e1 =
 				terminate cb (NextThrow e1) e.etype e.epos;

--- a/src/coro/coroToTexpr.ml
+++ b/src/coro/coroToTexpr.ml
@@ -112,8 +112,6 @@ let block_to_texpr_coroutine ctx cb cont cls tf_args forbidden_vars econtinuatio
 			add_state (Some next_state_id) ecallcoroutine;
 		| NextUnknown ->
 			add_state (Some (-1)) [set_control CoroReturned; ereturn]
-		| NextExit ->
-			add_state (Some (-1)) [ereturn]
 		| NextFallThrough cb_next | NextGoto cb_next | NextBreak cb_next | NextContinue cb_next ->
 			let rec skip_loop cb =
 				if DynArray.empty cb.cb_el then begin match cb.cb_next.next_kind with
@@ -284,12 +282,6 @@ let block_to_texpr_coroutine ctx cb cont cls tf_args forbidden_vars econtinuatio
 	List.iter (fun state ->
 		let rec loop e =
 			match e.eexpr with
-			(* TODO : Should this be handled here? *)
-			(* Also need to check if this should be the continuation instead of completion *)
-			| TCall ({ eexpr = TField (_, FStatic ({ cl_path = (["haxe";"coro"], "Intrinsics") }, { cf_name = "currentContinuation" })) }, []) ->
-				ecompletion
-			| TCall ({ eexpr = TField (_, FStatic ({ cl_path = (["haxe";"coro"], "Intrinsics") }, { cf_name = "outputContinuation" })) }, []) ->
-				econtinuation
 			| TVar (v, eo) when is_used_across_states v.v_id ->
 				let name = if v.v_kind = VGenerated then
 					Printf.sprintf "_hx_hoisted%i" v.v_id

--- a/src/coro/coroTypes.ml
+++ b/src/coro/coroTypes.ml
@@ -14,7 +14,6 @@ and coro_next_kind =
 	| NextSub of coro_block * coro_block
 	| NextReturnVoid
 	| NextReturn of texpr
-	| NextExit (* like return but doesn't update control state *)
 	| NextThrow of texpr
 	| NextIfThen of texpr * coro_block * coro_block
 	| NextIfThenElse of texpr * coro_block * coro_block * coro_block

--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -870,7 +870,7 @@ module TypeBinding = struct
 						| TBlock [] | TBlock [{ eexpr = TConst _ }] | TConst _ | TObjectDecl [] -> ()
 						| _ -> TClass.set_cl_init c e);
 					let e = mk (TFunction tf) t p in
-					let e = if TyperManager.is_coroutine_context ctx then Coro.fun_to_coro (Coro.create_coro_context ctx cf.cf_meta) (ClassField(c, cf, tf, p)) else e in
+					let e = if TyperManager.is_coroutine_context ctx && not (Meta.has Meta.CoroutineTransformed cf.cf_meta) then Coro.fun_to_coro (Coro.create_coro_context ctx cf.cf_meta) (ClassField(c, cf, tf, p)) else e in
 					cf.cf_expr <- Some e;
 					cf.cf_type <- t;
 					check_field_display ctx fctx c cf;
@@ -1261,7 +1261,18 @@ let create_method (ctx,cctx,fctx) c f cf fd p =
 	let is_coroutine = Meta.has Meta.Coroutine f.cff_meta in
 	let function_mode = if is_coroutine then FunCoroutine else FunFunction in
 	let targs = args#for_type in
-	let t = if is_coroutine then ctx.t.tcoro.tcoro targs ret else TFun (targs,ret) in
+	let t = if not is_coroutine then
+		TFun (targs,ret)
+	else if Meta.has Meta.CoroutineTransformed cf.cf_meta then begin
+		match List.rev targs with
+			| _ :: targs ->
+				(* Ignore trailing continuation for actual signature *)
+				ctx.t.tcoro.tcoro (List.rev targs) ret
+			| _ ->
+				die "" __LOC__
+	end else
+		ctx.t.tcoro.tcoro targs ret
+	in
 	cf.cf_type <- t;
 	cf.cf_kind <- Method (if fctx.is_macro then MethMacro else if fctx.is_inline then MethInline else if dynamic then MethDynamic else MethNormal);
 	cf.cf_params <- params;

--- a/std/haxe/coro/Coroutine.hx
+++ b/std/haxe/coro/Coroutine.hx
@@ -5,19 +5,29 @@ import haxe.coro.schedulers.EventLoopScheduler;
 import haxe.coro.continuations.RacingContinuation;
 import haxe.coro.continuations.BlockingContinuation;
 
+private class CoroSuspend extends haxe.coro.BaseContinuation {
+	public function new(completion:haxe.coro.IContinuation<Any>) {
+		super(completion, 1);
+	}
+
+	public function invokeResume() {
+		return Coroutine.suspend(null, this);
+	}
+}
+
 /**
 	Coroutine function.
 **/
 @:callable
 @:coreType
 abstract Coroutine<T:haxe.Constraints.Function> {
-	@:coroutine public static function suspend<T>(func:(IContinuation<Any>) -> Void) {
-		final inputCont = haxe.coro.Intrinsics.currentContinuation();
-		final outputCont = haxe.coro.Intrinsics.outputContinuation();
-		final safe = new RacingContinuation(inputCont, outputCont);
+	@:coroutine @:coroutine.transformed
+	public static function suspend<T>(func:haxe.coro.IContinuation<Any>->Void, _hx_completion:haxe.coro.IContinuation<Any>):T {
+		var _hx_continuation = new CoroSuspend(_hx_completion);
+		var safe = new haxe.coro.continuations.RacingContinuation(_hx_completion, _hx_continuation);
 		func(safe);
 		safe.resolve();
-		throw return;
+		return cast _hx_continuation;
 	}
 
 	@:coroutine public static function delay(ms:Int):Void {

--- a/std/haxe/coro/Intrinsics.hx
+++ b/std/haxe/coro/Intrinsics.hx
@@ -1,6 +1,5 @@
 package haxe.coro;
 
 extern class Intrinsics {
-    public static function currentContinuation():IContinuation<Any>;
-    public static function outputContinuation():ContinuationResult;
+
 }

--- a/tests/misc/coroutines/src/issues/aidan/Issue38.hx
+++ b/tests/misc/coroutines/src/issues/aidan/Issue38.hx
@@ -1,0 +1,13 @@
+package issues.aidan;
+
+@:coroutine function foo() : String {
+	return Coroutine.suspend(cont -> {
+		cont.resume('Hello, World!', null);
+	});
+}
+
+class Issue38 extends utest.Test {
+	function test() {
+		Assert.equals("Hello, World!", Coroutine.run(foo));
+	}
+}


### PR DESCRIPTION
This implements what I describe in https://github.com/Aidan63/haxe/issues/38#issuecomment-2813379820. If the metadata is present, the field is assumed to be a properly written coroutine and all calls to it are handled as such.

This allows us to remove all the hacks we had to make `suspend` work. The only downside I can see is that I'm not sure if we should really do this.