### PR TITLE
[demo] Interceptors

### DIFF
--- a/std/haxe/coro/BaseContinuation.hx
+++ b/std/haxe/coro/BaseContinuation.hx
@@ -3,40 +3,47 @@ package haxe.coro;
 import haxe.Exception;
 
 abstract class BaseContinuation<T> extends ContinuationResult<T> implements IContinuation<T> {
-    public final _hx_completion:IContinuation<Any>;
+	public final _hx_completion:IContinuation<Any>;
 
 	public final _hx_context:CoroutineContext;
 
-    public var _hx_state:Int;
+	public var _hx_state:Int;
 
-    public var _hx_recursing:Bool;
+	public var _hx_recursing:Bool;
 
-    function new(completion:IContinuation<Any>, initialState:Int) {
-        _hx_completion = completion;
-        _hx_context    = completion._hx_context;
-        _hx_state      = initialState;
-        _hx_error      = null;
-        _hx_result     = null;
-        _hx_recursing  = false;
-    }
+	public final name:String;
 
-    public final function resume(result:Any, error:Exception):Void {
-        _hx_result = result;
-        _hx_error  = error;
-        _hx_context.scheduler.schedule(() -> {
-		_hx_recursing = false;
+	function new(completion:IContinuation<Any>, initialState:Int) {
+		_hx_completion = completion;
+		_hx_context    = completion._hx_context;
+		_hx_state      = initialState;
+		_hx_error      = null;
+		_hx_result     = null;
+		_hx_recursing  = false;
+		name           = Type.getClassName(Type.getClass(this));
+	}
 
-		final result = invokeResume();
+	public final function resume(result:Any, error:Exception):Void {
+		_hx_result = result;
+		_hx_error  = error;
+		_hx_context.scheduler.schedule(() -> {
+			_hx_recursing = false;
+
+			final result = invokeResume();
 			switch (result._hx_control) {
 				case Pending:
 					return;
 				case Returned:
-					_hx_completion.resume(result._hx_result, null);
+					_hx_context.maybeIntercept(_hx_completion, result._hx_result, null);
 				case Thrown:
-					_hx_completion.resume(null, result._hx_error);
+					_hx_context.maybeIntercept(_hx_completion, null, result._hx_error);
 			}
-        });
-    }
+		});
+	}
 
-    abstract function invokeResume():ContinuationResult<T>;
+	abstract function invokeResume():ContinuationResult<T>;
+
+	override public function toString() {
+		return '[$name state $_hx_state, ${super.toString()}]';
+	}
 }

--- a/std/haxe/coro/ContinuationInterceptor.hx
+++ b/std/haxe/coro/ContinuationInterceptor.hx
@@ -1,0 +1,9 @@
+package haxe.coro;
+
+abstract class ContinuationInterceptor {
+	public function new() { }
+
+	public abstract function intercept<T>(continuation:IContinuation<T>):IContinuation<T>;
+
+	public function release<T>(continuation:IContinuation<T>) {}
+}

--- a/std/haxe/coro/CoroutineContext.hx
+++ b/std/haxe/coro/CoroutineContext.hx
@@ -2,8 +2,21 @@ package haxe.coro;
 
 class CoroutineContext {
     public final scheduler : IScheduler;
+	public var interceptor : Null<ContinuationInterceptor>;
 
     public function new(scheduler) {
         this.scheduler = scheduler;
     }
+
+	public function maybeIntercept<T>(continuation:IContinuation<T>, result:Null<T>, error:Null<Exception>) {
+		if (interceptor != null) {
+			final cont = interceptor.intercept(continuation);
+			cont.resume(result, error);
+			if (cont != continuation) {
+				interceptor.release(cont);
+			}
+		} else {
+			continuation.resume(result, error);
+		}
+	}
 }

--- a/std/haxe/coro/continuations/BlockingContinuation.hx
+++ b/std/haxe/coro/continuations/BlockingContinuation.hx
@@ -35,4 +35,8 @@ class BlockingContinuation<T> implements IContinuation<T> {
 			return result;
 		}
 	}
+
+	public function toString() {
+		return '[BlockingContinuation running: $running]';
+	}
 }

--- a/std/haxe/coro/continuations/RacingContinuation.hx
+++ b/std/haxe/coro/continuations/RacingContinuation.hx
@@ -52,7 +52,7 @@ private class Thread {
 
 			if (assigned) {
 				lock.release();
-				inputCont.resume(result, error);
+				_hx_context.maybeIntercept(inputCont, result, error);
 			} else {
 				assigned = true;
 				outputCont._hx_result = result;


### PR DESCRIPTION
I wanted to understand what Kotlin interceptors do, so I implemented what I _think_ they do. I don't think we actually want to have this in the default implementation because I feel like it messes things up too much.

This is my demo program:

```haxe
import haxe.Exception;
import haxe.coro.IContinuation;
import haxe.coro.Coroutine;
import haxe.coro.Coroutine.delay;
import haxe.coro.continuations.BlockingContinuation;
import haxe.coro.EventLoop;
import haxe.coro.CoroutineContext;
import haxe.coro.schedulers.EventLoopScheduler;

@:coroutine function test() {
	fancyPrint('hello');

	delay(1000);

	fancyPrint('world');

	return "done";
}

@:coroutine function fancyPrint(text:String):Void {
	for (i in 0...text.length) {
		Sys.print(text.charAt(i));

		delay(100);
	}

	Sys.print('\n');
}

class PrintingContinuation<T> implements IContinuation<T> {
	public final _hx_context:CoroutineContext;
	final continuation:IContinuation<T>;

	public function new(cont:IContinuation<T>) {
		_hx_context = cont._hx_context;
		continuation = cont;
	}

	public function resume(result:T, error:Exception) {
		trace(continuation, result, error);
		continuation.resume(result, error);
	}
}

class PrintingInterceptor extends haxe.coro.ContinuationInterceptor {
	function intercept<T>(cont:IContinuation<T>) {
		return new PrintingContinuation(cont);
	}
}

function main() {
	final loop = new EventLoop();
	final cont = new BlockingContinuation(loop, new EventLoopScheduler(loop));
	final interceptor = new PrintingInterceptor();
	cont._hx_context.interceptor = interceptor;
	final result = test(cont);

	var r = switch (result._hx_control) {
		case Pending:
			cont.wait();
		case Returned:
			result._hx_result;
		case Thrown:
			throw result._hx_error;
	}
	trace(r);
}
```

I had to reimplement `Coroutine.run` because I have to add the interceptor to the context, and I didn't know how to do that otherwise. This will print the resume calls:

```
hsource/Main.hx:40: [haxe.coro._Coroutine.HxCoro_haxe_coro_Coroutine_delay state 2, [ContinuationResult Pending, null]], null, null
source/Main.hx:40: [_Main.HxCoro__Main_fancyPrint state 9, [ContinuationResult Pending, null]], null, null
esource/Main.hx:40: [haxe.coro._Coroutine.HxCoro_haxe_coro_Coroutine_delay state 2, [ContinuationResult Pending, null]], null, null
source/Main.hx:40: [_Main.HxCoro__Main_fancyPrint state 9, [ContinuationResult Pending, null]], null, null
lsource/Main.hx:40: [haxe.coro._Coroutine.HxCoro_haxe_coro_Coroutine_delay state 2, [ContinuationResult Pending, null]], null, null
source/Main.hx:40: [_Main.HxCoro__Main_fancyPrint state 9, [ContinuationResult Pending, null]], null, null
lsource/Main.hx:40: [haxe.coro._Coroutine.HxCoro_haxe_coro_Coroutine_delay state 2, [ContinuationResult Pending, null]], null, null
source/Main.hx:40: [_Main.HxCoro__Main_fancyPrint state 9, [ContinuationResult Pending, null]], null, null
osource/Main.hx:40: [haxe.coro._Coroutine.HxCoro_haxe_coro_Coroutine_delay state 2, [ContinuationResult Pending, null]], null, null
source/Main.hx:40: [_Main.HxCoro__Main_fancyPrint state 9, [ContinuationResult Pending, null]], null, null

source/Main.hx:40: [_Main.HxCoro__Main_test state 2, [ContinuationResult Pending, null]], null, null
source/Main.hx:40: [haxe.coro._Coroutine.HxCoro_haxe_coro_Coroutine_delay state 2, [ContinuationResult Pending, null]], null, null
source/Main.hx:40: [_Main.HxCoro__Main_test state 3, [ContinuationResult Pending, null]], null, null
wsource/Main.hx:40: [haxe.coro._Coroutine.HxCoro_haxe_coro_Coroutine_delay state 2, [ContinuationResult Pending, null]], null, null
source/Main.hx:40: [_Main.HxCoro__Main_fancyPrint state 9, [ContinuationResult Pending, null]], null, null
osource/Main.hx:40: [haxe.coro._Coroutine.HxCoro_haxe_coro_Coroutine_delay state 2, [ContinuationResult Pending, null]], null, null
source/Main.hx:40: [_Main.HxCoro__Main_fancyPrint state 9, [ContinuationResult Pending, null]], null, null
rsource/Main.hx:40: [haxe.coro._Coroutine.HxCoro_haxe_coro_Coroutine_delay state 2, [ContinuationResult Pending, null]], null, null
source/Main.hx:40: [_Main.HxCoro__Main_fancyPrint state 9, [ContinuationResult Pending, null]], null, null
lsource/Main.hx:40: [haxe.coro._Coroutine.HxCoro_haxe_coro_Coroutine_delay state 2, [ContinuationResult Pending, null]], null, null
source/Main.hx:40: [_Main.HxCoro__Main_fancyPrint state 9, [ContinuationResult Pending, null]], null, null
dsource/Main.hx:40: [haxe.coro._Coroutine.HxCoro_haxe_coro_Coroutine_delay state 2, [ContinuationResult Pending, null]], null, null
source/Main.hx:40: [_Main.HxCoro__Main_fancyPrint state 9, [ContinuationResult Pending, null]], null, null

source/Main.hx:40: [_Main.HxCoro__Main_test state 4, [ContinuationResult Pending, null]], null, null
source/Main.hx:40: [BlockingContinuation running: true], done, null
source/Main.hx:66: done
```

I don't know if there's more to interceptors, I think there must be. But it's nice that this can work with just a few changes. 