### PR TITLE
Optimize CFG a bit

### DIFF
--- a/src/coro/coro.ml
+++ b/src/coro/coro.ml
@@ -266,6 +266,7 @@ let fun_to_coro ctx coro_type =
 	let cb_root = make_block ctx (Some(expr.etype, null_pos)) in
 
 	ignore(CoroFromTexpr.expr_to_coro ctx eresult cb_root expr);
+	let cb_root = CoroFromTexpr.optimize_cfg ctx cb_root in
 	let exprs = {CoroToTexpr.econtinuation;ecompletion;econtrol;eresult;estate;eerror} in
 	let eloop, eif_error, initial_state, fields = CoroToTexpr.block_to_texpr_coroutine ctx cb_root cont coro_class.cls args [ vcompletion.v_id; vcontinuation.v_id ] exprs null_pos in
 	(* update cf_type to use inside type parameters *)

--- a/src/coro/coroFromTexpr.ml
+++ b/src/coro/coroFromTexpr.ml
@@ -325,90 +325,6 @@ let expr_to_coro ctx eresult cb_root e =
 	in
 	loop_block cb_root RBlock e
 
-let coro_iter f cb =
-	Option.may f cb.cb_catch;
-	match cb.cb_next with
-	| NextSub(cb_sub,cb_next) ->
-		f cb_sub;
-		f cb_next
-	| NextIfThen(_,cb_then,cb_next) ->
-		f cb_then;
-		f cb_next;
-	| NextIfThenElse(_,cb_then,cb_else,cb_next) ->
-		f cb_then;
-		f cb_else;
-		f cb_next;
-	| NextSwitch(switch,cb_next) ->
-		List.iter (fun (_,cb) -> f cb) switch.cs_cases;
-		Option.may f switch.cs_default;
-		f cb_next;
-	| NextWhile(e,cb_body,cb_next) ->
-		f cb_body;
-		f cb_next;
-	| NextTry(cb_try,catch,cb_next) ->
-		f cb_try;
-		f catch.cc_cb;
-		List.iter (fun (_,cb) -> f cb) catch.cc_catches;
-		f cb_next;
-	| NextSuspend(call,cb_next) ->
-		f cb_next
-	| NextBreak cb_next | NextContinue cb_next | NextFallThrough cb_next | NextGoto cb_next ->
-		f cb_next;
-	| NextUnknown | NextReturnVoid | NextReturn _ | NextThrow _ ->
-		()
-
-let coro_next_map f cb =
-	Option.may (fun cb_catch -> cb.cb_catch <- Some (f cb_catch)) cb.cb_catch;
-	match cb.cb_next with
-	| NextSub(cb_sub,cb_next) ->
-		let cb_sub = f cb_sub in
-		let cb_next = f cb_next in
-		cb.cb_next <- NextSub(cb_sub,cb_next);
-	| NextIfThen(e,cb_then,cb_next) ->
-		let cb_then = f cb_then in
-		let cb_next = f cb_next in
-		cb.cb_next <- NextIfThen(e,cb_then,cb_next);
-	| NextIfThenElse(e,cb_then,cb_else,cb_next) ->
-		let cb_then = f cb_then in
-		let cb_else = f cb_else in
-		let cb_next = f cb_next in
-		cb.cb_next <- NextIfThenElse(e,cb_then,cb_else,cb_next);
-	| NextSwitch(switch,cb_next) ->
-		let cases = List.map (fun (el,cb) -> (el,f cb)) switch.cs_cases in
-		let def = Option.map f switch.cs_default in
-		let switch = {
-			switch with cs_cases = cases; cs_default = def
-		} in
-		let cb_next = f cb_next in
-		cb.cb_next <- NextSwitch(switch,cb_next);
-	| NextWhile(e,cb_body,cb_next) ->
-		let cb_body = f cb_body in
-		let cb_next = f cb_next in
-		cb.cb_next <- NextWhile(e,cb_body,cb_next);
-	| NextTry(cb_try,catch,cb_next) ->
-		let cb_try = f cb_try in
-		let cc_cb = f catch.cc_cb in
-		let catches = List.map (fun (v,cb) -> (v,f cb)) catch.cc_catches in
-		let catch = {
-			cc_cb;
-			cc_catches = catches
-		} in
-		let cb_next = f cb_next in
-		cb.cb_next <- NextTry(cb_try,catch,cb_next);
-	| NextSuspend(call,cb_next) ->
-		let cb_next = f cb_next in
-		cb.cb_next <- NextSuspend(call,cb_next);
-	| NextBreak cb_next ->
-		cb.cb_next <- NextBreak (f cb_next);
-	| NextContinue cb_next ->
-		cb.cb_next <- NextContinue (f cb_next);
-	| NextGoto cb_next ->
-		cb.cb_next <- NextContinue (f cb_next);
-	| NextFallThrough cb_next ->
-		cb.cb_next <- NextFallThrough (f cb_next);
-	| NextReturnVoid | NextReturn _ | NextThrow _ | NextUnknown ->
-		()
-
 let optimize_cfg ctx cb =
 	let forward_el cb_from cb_to =
 		if DynArray.length cb_from.cb_el > 0 then begin
@@ -430,7 +346,7 @@ let optimize_cfg ctx cb =
 				loop cb_sub;
 				forward_el cb cb_sub;
 				forward.(cb.cb_id) <- Some cb_sub
-			| NextFallThrough cb_next | NextGoto cb_next | NextBreak cb_next | NextContinue cb_next when DynArray.length cb.cb_el = 0 ->
+			| NextFallThrough cb_next | NextGoto cb_next | NextBreak cb_next | NextContinue cb_next when DynArray.empty cb.cb_el ->
 				loop cb_next;
 				forward.(cb.cb_id) <- Some cb_next
 			| _ ->

--- a/src/coro/coroFromTexpr.ml
+++ b/src/coro/coroFromTexpr.ml
@@ -247,11 +247,15 @@ let expr_to_coro ctx eresult cb_root e =
 			let cb_next = make_block None in
 			let catches = List.map (fun (v,e) ->
 				let cb_catch = block_from_e e in
+				add_expr cb_catch (mk (TVar(v,Some eresult)) ctx.typer.t.tvoid null_pos);
 				let cb_catch_next,_ = loop_block cb_catch ret e in
 				fall_through cb_catch_next cb_next;
 				v,cb_catch
 			) catches in
 			let catch = make_block None in
+			(* This block is handled in a special way in the texpr transformer, let's mark it as
+			   already generated so we don't generate it twice. *)
+			add_block_flag catch CbGenerated;
 			let old = ctx.current_catch in
 			ctx.current_catch <- Some catch;
 			let catch = {

--- a/src/coro/coroFromTexpr.ml
+++ b/src/coro/coroFromTexpr.ml
@@ -345,6 +345,7 @@ let coro_iter f cb =
 		f cb_try;
 		f catch.cc_cb;
 		List.iter (fun (_,cb) -> f cb) catch.cc_catches;
+		f cb_next;
 	| NextSuspend(call,cb_next) ->
 		f cb_next
 	| NextBreak cb_next | NextContinue cb_next | NextFallThrough cb_next | NextGoto cb_next ->
@@ -353,6 +354,7 @@ let coro_iter f cb =
 		()
 
 let coro_next_map f cb =
+	Option.may (fun cb_catch -> cb.cb_catch <- Some (f cb_catch)) cb.cb_catch;
 	match cb.cb_next with
 	| NextSub(cb_sub,cb_next) ->
 		let cb_sub = f cb_sub in
@@ -444,9 +446,8 @@ let optimize_cfg ctx cb =
 			cb
 	in
 	let cb = loop cb in
-	(* TODO: this doesn't work yet due to some problem with catches, probably related to cb.cb_catch not being mapped properly *)
 	(* third pass: reindex cb_id for tighter switches. Breadth-first because that makes the numbering more natural, maybe. *)
-	(* let i = ref 0 in
+	let i = ref 0 in
 	let queue = Queue.create () in
 	Queue.push cb queue;
 	let rec loop () =
@@ -462,5 +463,6 @@ let optimize_cfg ctx cb =
 			loop ()
 		end
 	in
-	loop (); *)
+	loop ();
+	ctx.next_block_id <- !i;
 	cb

--- a/src/coro/coroFromTexpr.ml
+++ b/src/coro/coroFromTexpr.ml
@@ -320,3 +320,147 @@ let expr_to_coro ctx eresult cb_root e =
 				aux' cb el
 	in
 	loop_block cb_root RBlock e
+
+let coro_iter f cb =
+	Option.may f cb.cb_catch;
+	match cb.cb_next with
+	| NextSub(cb_sub,cb_next) ->
+		f cb_sub;
+		f cb_next
+	| NextIfThen(_,cb_then,cb_next) ->
+		f cb_then;
+		f cb_next;
+	| NextIfThenElse(_,cb_then,cb_else,cb_next) ->
+		f cb_then;
+		f cb_else;
+		f cb_next;
+	| NextSwitch(switch,cb_next) ->
+		List.iter (fun (_,cb) -> f cb) switch.cs_cases;
+		Option.may f switch.cs_default;
+		f cb_next;
+	| NextWhile(e,cb_body,cb_next) ->
+		f cb_body;
+		f cb_next;
+	| NextTry(cb_try,catch,cb_next) ->
+		f cb_try;
+		f catch.cc_cb;
+		List.iter (fun (_,cb) -> f cb) catch.cc_catches;
+	| NextSuspend(call,cb_next) ->
+		f cb_next
+	| NextBreak cb_next | NextContinue cb_next | NextFallThrough cb_next | NextGoto cb_next ->
+		f cb_next;
+	| NextUnknown | NextReturnVoid | NextReturn _ | NextThrow _ ->
+		()
+
+let coro_next_map f cb =
+	match cb.cb_next with
+	| NextSub(cb_sub,cb_next) ->
+		let cb_sub = f cb_sub in
+		let cb_next = f cb_next in
+		cb.cb_next <- NextSub(cb_sub,cb_next);
+	| NextIfThen(e,cb_then,cb_next) ->
+		let cb_then = f cb_then in
+		let cb_next = f cb_next in
+		cb.cb_next <- NextIfThen(e,cb_then,cb_next);
+	| NextIfThenElse(e,cb_then,cb_else,cb_next) ->
+		let cb_then = f cb_then in
+		let cb_else = f cb_else in
+		let cb_next = f cb_next in
+		cb.cb_next <- NextIfThenElse(e,cb_then,cb_else,cb_next);
+	| NextSwitch(switch,cb_next) ->
+		let cases = List.map (fun (el,cb) -> (el,f cb)) switch.cs_cases in
+		let def = Option.map f switch.cs_default in
+		let switch = {
+			switch with cs_cases = cases; cs_default = def
+		} in
+		let cb_next = f cb_next in
+		cb.cb_next <- NextSwitch(switch,cb_next);
+	| NextWhile(e,cb_body,cb_next) ->
+		let cb_body = f cb_body in
+		let cb_next = f cb_next in
+		cb.cb_next <- NextWhile(e,cb_body,cb_next);
+	| NextTry(cb_try,catch,cb_next) ->
+		let cb_try = f cb_try in
+		let cc_cb = f catch.cc_cb in
+		let catches = List.map (fun (v,cb) -> (v,f cb)) catch.cc_catches in
+		let catch = {
+			cc_cb;
+			cc_catches = catches
+		} in
+		let cb_next = f cb_next in
+		cb.cb_next <- NextTry(cb_try,catch,cb_next);
+	| NextSuspend(call,cb_next) ->
+		let cb_next = f cb_next in
+		cb.cb_next <- NextSuspend(call,cb_next);
+	| NextBreak cb_next ->
+		cb.cb_next <- NextBreak (f cb_next);
+	| NextContinue cb_next ->
+		cb.cb_next <- NextContinue (f cb_next);
+	| NextGoto cb_next ->
+		cb.cb_next <- NextContinue (f cb_next);
+	| NextFallThrough cb_next ->
+		cb.cb_next <- NextFallThrough (f cb_next);
+	| NextReturnVoid | NextReturn _ | NextThrow _ | NextUnknown ->
+		()
+
+let optimize_cfg ctx cb =
+	let forward_el cb_from cb_to =
+		if DynArray.length cb_from.cb_el > 0 then begin
+			if DynArray.length cb_to.cb_el = 0 then begin
+				DynArray.iter (fun e -> DynArray.add cb_to.cb_el e) cb_from.cb_el
+			end else begin
+				let e = mk (TBlock (DynArray.to_list cb_from.cb_el)) ctx.typer.t.tvoid null_pos in
+				DynArray.set cb_to.cb_el 0 (concat e (DynArray.get cb_to.cb_el 0))
+			end
+		end
+	in
+	(* first pass: find empty blocks and store their replacement*)
+	let forward = Array.make ctx.next_block_id None in
+	let rec loop cb =
+		if not (has_block_flag cb CbEmptyMarked) then begin
+			add_block_flag cb CbEmptyMarked;
+			match cb.cb_next with
+			| NextSub(cb_sub,cb_next) when cb_next == ctx.cb_unreachable ->
+				loop cb_sub;
+				forward_el cb cb_sub;
+				forward.(cb.cb_id) <- Some cb_sub
+			| NextFallThrough cb_next | NextGoto cb_next | NextBreak cb_next | NextContinue cb_next when DynArray.length cb.cb_el = 0 ->
+				loop cb_next;
+				forward.(cb.cb_id) <- Some cb_next
+			| _ ->
+				coro_iter loop cb
+		end
+	in
+	loop cb;
+	(* second pass: map graph to skip forwarding block *)
+	let rec loop cb = match forward.(cb.cb_id) with
+		| Some cb ->
+			loop cb
+		| None ->
+			if not (has_block_flag cb CbForwardMarked) then begin
+				add_block_flag cb CbForwardMarked;
+				coro_next_map loop cb;
+			end;
+			cb
+	in
+	let cb = loop cb in
+	(* TODO: this doesn't work yet due to some problem with catches, probably related to cb.cb_catch not being mapped properly *)
+	(* third pass: reindex cb_id for tighter switches. Breadth-first because that makes the numbering more natural, maybe. *)
+	(* let i = ref 0 in
+	let queue = Queue.create () in
+	Queue.push cb queue;
+	let rec loop () =
+		if not (Queue.is_empty queue) then begin
+			let cb = Queue.pop queue in
+			if not (has_block_flag cb CbReindexed) then begin
+				add_block_flag cb CbReindexed;
+				cb.cb_id <- !i;
+				incr i;
+				coro_iter (fun cb -> Queue.add cb queue) cb;
+				Option.may (fun cb -> Queue.add cb queue) cb.cb_catch;
+			end;
+			loop ()
+		end
+	in
+	loop (); *)
+	cb

--- a/src/coro/coroFunctions.ml
+++ b/src/coro/coroFunctions.ml
@@ -19,3 +19,87 @@ let add_block_flag cb (flag : cb_flag) =
 
 let has_block_flag cb (flag : cb_flag) =
 	has_flag cb.cb_flags (Obj.magic flag)
+
+let coro_iter f cb =
+	Option.may f cb.cb_catch;
+	match cb.cb_next with
+	| NextSub(cb_sub,cb_next) ->
+		f cb_sub;
+		f cb_next
+	| NextIfThen(_,cb_then,cb_next) ->
+		f cb_then;
+		f cb_next;
+	| NextIfThenElse(_,cb_then,cb_else,cb_next) ->
+		f cb_then;
+		f cb_else;
+		f cb_next;
+	| NextSwitch(switch,cb_next) ->
+		List.iter (fun (_,cb) -> f cb) switch.cs_cases;
+		Option.may f switch.cs_default;
+		f cb_next;
+	| NextWhile(e,cb_body,cb_next) ->
+		f cb_body;
+		f cb_next;
+	| NextTry(cb_try,catch,cb_next) ->
+		f cb_try;
+		f catch.cc_cb;
+		List.iter (fun (_,cb) -> f cb) catch.cc_catches;
+		f cb_next;
+	| NextSuspend(call,cb_next) ->
+		f cb_next
+	| NextBreak cb_next | NextContinue cb_next | NextFallThrough cb_next | NextGoto cb_next ->
+		f cb_next;
+	| NextUnknown | NextReturnVoid | NextReturn _ | NextThrow _ ->
+		()
+
+let coro_next_map f cb =
+	Option.may (fun cb_catch -> cb.cb_catch <- Some (f cb_catch)) cb.cb_catch;
+	match cb.cb_next with
+	| NextSub(cb_sub,cb_next) ->
+		let cb_sub = f cb_sub in
+		let cb_next = f cb_next in
+		cb.cb_next <- NextSub(cb_sub,cb_next);
+	| NextIfThen(e,cb_then,cb_next) ->
+		let cb_then = f cb_then in
+		let cb_next = f cb_next in
+		cb.cb_next <- NextIfThen(e,cb_then,cb_next);
+	| NextIfThenElse(e,cb_then,cb_else,cb_next) ->
+		let cb_then = f cb_then in
+		let cb_else = f cb_else in
+		let cb_next = f cb_next in
+		cb.cb_next <- NextIfThenElse(e,cb_then,cb_else,cb_next);
+	| NextSwitch(switch,cb_next) ->
+		let cases = List.map (fun (el,cb) -> (el,f cb)) switch.cs_cases in
+		let def = Option.map f switch.cs_default in
+		let switch = {
+			switch with cs_cases = cases; cs_default = def
+		} in
+		let cb_next = f cb_next in
+		cb.cb_next <- NextSwitch(switch,cb_next);
+	| NextWhile(e,cb_body,cb_next) ->
+		let cb_body = f cb_body in
+		let cb_next = f cb_next in
+		cb.cb_next <- NextWhile(e,cb_body,cb_next);
+	| NextTry(cb_try,catch,cb_next) ->
+		let cb_try = f cb_try in
+		let cc_cb = f catch.cc_cb in
+		let catches = List.map (fun (v,cb) -> (v,f cb)) catch.cc_catches in
+		let catch = {
+			cc_cb;
+			cc_catches = catches
+		} in
+		let cb_next = f cb_next in
+		cb.cb_next <- NextTry(cb_try,catch,cb_next);
+	| NextSuspend(call,cb_next) ->
+		let cb_next = f cb_next in
+		cb.cb_next <- NextSuspend(call,cb_next);
+	| NextBreak cb_next ->
+		cb.cb_next <- NextBreak (f cb_next);
+	| NextContinue cb_next ->
+		cb.cb_next <- NextContinue (f cb_next);
+	| NextGoto cb_next ->
+		cb.cb_next <- NextContinue (f cb_next);
+	| NextFallThrough cb_next ->
+		cb.cb_next <- NextFallThrough (f cb_next);
+	| NextReturnVoid | NextReturn _ | NextThrow _ | NextUnknown ->
+		()

--- a/src/coro/coroFunctions.ml
+++ b/src/coro/coroFunctions.ml
@@ -11,4 +11,11 @@ let make_block ctx typepos =
 		cb_typepos = typepos;
 		cb_next = NextUnknown;
 		cb_catch = ctx.current_catch;
+		cb_flags = 0;
 	}
+
+let add_block_flag cb (flag : cb_flag) =
+	cb.cb_flags <- set_flag cb.cb_flags (Obj.magic flag)
+
+let has_block_flag cb (flag : cb_flag) =
+	has_flag cb.cb_flags (Obj.magic flag)

--- a/src/coro/coroToTexpr.ml
+++ b/src/coro/coroToTexpr.ml
@@ -117,18 +117,12 @@ let block_to_texpr_coroutine ctx cb cont cls tf_args forbidden_vars exprs p =
 		end in
 		loop (DynArray.length cb.cb_el - 1) []
 	in
-	let rec loop cb current_el =
-		if not (has_block_flag cb CbGenerated) then begin
-			add_block_flag cb CbGenerated;
-			generate cb current_el
-		end else
-			cb.cb_id
-	and generate cb current_el =
+	let generate cb =
 		assert (cb != ctx.cb_unreachable);
 		let el = get_block_exprs cb in
 
 		let add_state next_id extra_el =
-			let el = current_el @ el @ extra_el in
+			let el = el @ extra_el in
 			let el = match next_id with
 				| None ->
 					el
@@ -147,9 +141,8 @@ let block_to_texpr_coroutine ctx cb cont cls tf_args forbidden_vars exprs p =
 		in
 		match cb.cb_next with
 		| NextSuspend (call, cb_next) ->
-			let next_state_id = loop cb_next [] in
 			let ecallcoroutine = mk_suspending_call call in
-			add_state (Some next_state_id) ecallcoroutine;
+			add_state (Some cb_next.cb_id) ecallcoroutine;
 		| NextUnknown ->
 			add_state (Some (-1)) [set_control CoroReturned; ereturn]
 		| NextFallThrough cb_next | NextGoto cb_next | NextBreak cb_next | NextContinue cb_next ->
@@ -160,53 +153,39 @@ let block_to_texpr_coroutine ctx cb cont cls tf_args forbidden_vars exprs p =
 			add_state (Some (-1)) [ set_control CoroReturned; assign eresult e; ereturn ]
 		| NextThrow e1 ->
 			add_state None [ assign eresult e1; mk TBreak t_dynamic p ]
-		| NextSub (bb_sub,bb_next) ->
-			let next_state_id = loop bb_next [] in
-			let sub_state_id = loop bb_sub [] in
-			ignore(next_state_id);
-			add_state (Some sub_state_id) []
+		| NextSub (cb_sub,cb_next) ->
+			ignore(cb_next.cb_id);
+			add_state (Some cb_sub.cb_id) []
 
-		| NextIfThen (econd,bb_then,bb_next) ->
-			let next_state_id = loop bb_next [] in
-			let then_state_id = loop bb_then [] in
-			let eif = mk (TIf (econd, set_state then_state_id, Some (set_state next_state_id))) com.basic.tint p in
+		| NextIfThen (econd,cb_then,cb_next) ->
+			let eif = mk (TIf (econd, set_state cb_then.cb_id, Some (set_state cb_next.cb_id))) com.basic.tint p in
 			add_state None [eif]
 
-		| NextIfThenElse (econd,bb_then,bb_else,bb_next) ->
-			let _ = loop bb_next [] in
-			let then_state_id = loop bb_then [] in
-			let else_state_id = loop bb_else [] in
-			let eif = mk (TIf (econd, set_state then_state_id, Some (set_state else_state_id))) com.basic.tint p in
+		| NextIfThenElse (econd,cb_then,cb_else,cb_next) ->
+			let eif = mk (TIf (econd, set_state cb_then.cb_id, Some (set_state cb_else.cb_id))) com.basic.tint p in
 			add_state None [eif]
 
-		| NextSwitch(switch, bb_next) ->
+		| NextSwitch(switch,cb_next) ->
 			let esubj = switch.cs_subject in
-			let next_state_id = loop bb_next [] in
-			let ecases = List.map (fun (patterns,bb) ->
-				let case_state_id = loop bb [] in
-				{case_patterns = patterns;case_expr = set_state case_state_id}
+			let ecases = List.map (fun (patterns,cb) ->
+				{case_patterns = patterns;case_expr = set_state cb.cb_id}
 			) switch.cs_cases in
 			let default_state_id = match switch.cs_default with
-				| Some bb ->
-					let default_state_id = loop bb [] in
-					default_state_id
+				| Some cb ->
+					cb.cb_id
 				| None ->
-					next_state_id
+					cb_next.cb_id
 			in
 			let eswitch = mk_switch esubj ecases (Some (set_state default_state_id)) true in
 			let eswitch = mk (TSwitch eswitch) com.basic.tvoid p in
 
 			add_state None [eswitch]
 
-		| NextWhile (e_cond, bb_body, bb_next) ->
-			let body_state_id = loop bb_body [] in
-			let _ = loop bb_next [] in
-			add_state (Some body_state_id) []
+		| NextWhile (e_cond,cb_body,cb_next) ->
+			add_state (Some cb_body.cb_id) []
 
-		| NextTry (bb_try,catch,bb_next) ->
+		| NextTry (cb_try,catch,cb_next) ->
 			let new_exc_state_id = catch.cc_cb.cb_id in
-			let _ = loop bb_next [] in
-			let try_state_id = loop bb_try [] in
 			let erethrow = match catch.cc_cb.cb_catch with
 				| Some cb ->
 					set_state cb.cb_id
@@ -217,21 +196,26 @@ let block_to_texpr_coroutine ctx cb cont cls tf_args forbidden_vars exprs p =
 				]) t_dynamic null_pos
 			in
 			let eif =
-				List.fold_left (fun enext (vcatch,bb_catch) ->
-					let ecatchvar = mk (TVar (vcatch, Some eresult)) com.basic.tvoid null_pos in
-					let catch_state_id = loop bb_catch [ecatchvar] in
+				List.fold_left (fun enext (vcatch,cb_catch) ->
 					match follow vcatch.v_type with
 					| TDynamic _ ->
-						set_state catch_state_id (* no next *)
+						set_state cb_catch.cb_id (* no next *)
 					| t ->
 						let etypecheck = std_is eresult vcatch.v_type in
-						mk (TIf (etypecheck, set_state catch_state_id, Some enext)) com.basic.tvoid null_pos
+						mk (TIf (etypecheck, set_state cb_catch.cb_id, Some enext)) com.basic.tvoid null_pos
 				) erethrow (List.rev catch.cc_catches)
 			in
 			states := (make_state new_exc_state_id [eif]) :: !states;
-			add_state (Some try_state_id) []
+			add_state (Some cb_try.cb_id) []
 	in
-	ignore(loop cb []);
+	let rec loop cb =
+		if not (has_block_flag cb CbGenerated) then begin
+			add_block_flag cb CbGenerated;
+			ignore(generate cb);
+			CoroFromTexpr.coro_iter loop cb;
+		end
+	in
+	loop cb;
 
 	let states = !states in
 	let rethrow_state_id = cb_uncaught.cb_id in

--- a/src/coro/coroToTexpr.ml
+++ b/src/coro/coroToTexpr.ml
@@ -212,7 +212,7 @@ let block_to_texpr_coroutine ctx cb cont cls tf_args forbidden_vars exprs p =
 		if not (has_block_flag cb CbGenerated) then begin
 			add_block_flag cb CbGenerated;
 			ignore(generate cb);
-			CoroFromTexpr.coro_iter loop cb;
+			coro_iter loop cb;
 		end
 	in
 	loop cb;

--- a/src/coro/coroToTexpr.ml
+++ b/src/coro/coroToTexpr.ml
@@ -1,5 +1,6 @@
 open Globals
 open CoroTypes
+open CoroFunctions
 open Type
 open Texpr
 open CoroControl
@@ -117,6 +118,12 @@ let block_to_texpr_coroutine ctx cb cont cls tf_args forbidden_vars exprs p =
 		loop (DynArray.length cb.cb_el - 1) []
 	in
 	let rec loop cb current_el =
+		if not (has_block_flag cb CbGenerated) then begin
+			add_block_flag cb CbGenerated;
+			generate cb current_el
+		end else
+			cb.cb_id
+	and generate cb current_el =
 		assert (cb != ctx.cb_unreachable);
 		let el = get_block_exprs cb in
 

--- a/src/coro/coroToTexpr.ml
+++ b/src/coro/coroToTexpr.ml
@@ -86,7 +86,7 @@ let block_to_texpr_coroutine ctx cb cont cls tf_args forbidden_vars exprs p =
 
 	let states = ref [] in
 
-	let init_state = ref 1 in
+	let init_state = cb.cb_id in
 
 	let make_state id el = {
 		cs_id = id;
@@ -101,9 +101,24 @@ let block_to_texpr_coroutine ctx cb cont cls tf_args forbidden_vars exprs p =
 			die "" __LOC__
 	in
 	let exc_state_map = Array.init ctx.next_block_id (fun _ -> ref []) in
+	let get_block_exprs cb =
+		let rec loop idx acc =
+		if idx < 0 then
+			acc
+		else begin
+			let acc = match DynArray.unsafe_get cb.cb_el idx with
+				| {eexpr = TBlock el} ->
+					el @ acc
+				| e ->
+					e :: acc
+			in
+			loop (idx - 1) acc
+		end in
+		loop (DynArray.length cb.cb_el - 1) []
+	in
 	let rec loop cb current_el =
 		assert (cb != ctx.cb_unreachable);
-		let el = DynArray.to_list cb.cb_el in
+		let el = get_block_exprs cb in
 
 		let add_state next_id extra_el =
 			let el = current_el @ el @ extra_el in
@@ -131,30 +146,13 @@ let block_to_texpr_coroutine ctx cb cont cls tf_args forbidden_vars exprs p =
 		| NextUnknown ->
 			add_state (Some (-1)) [set_control CoroReturned; ereturn]
 		| NextFallThrough cb_next | NextGoto cb_next | NextBreak cb_next | NextContinue cb_next ->
-			let rec skip_loop cb =
-				if DynArray.empty cb.cb_el then begin match cb.cb_next with
-					| NextFallThrough cb_next | NextGoto cb_next | NextBreak cb_next | NextContinue cb_next ->
-						skip_loop cb_next
-					| _ ->
-						cb.cb_id
-				end else
-					cb.cb_id
-			in
-			if not (DynArray.empty cb.cb_el) then
-				add_state (Some (skip_loop cb_next)) []
-			else
-				skip_loop cb
+			add_state (Some cb_next.cb_id) []
 		| NextReturnVoid ->
 			add_state (Some (-1)) [ set_control CoroReturned; ereturn ]
 		| NextReturn e ->
 			add_state (Some (-1)) [ set_control CoroReturned; assign eresult e; ereturn ]
 		| NextThrow e1 ->
 			add_state None [ assign eresult e1; mk TBreak t_dynamic p ]
-		| NextSub (cb_sub,cb_next) when cb_next == ctx.cb_unreachable ->
-			(* If we're skipping our initial state we have to track this for the _hx_state init *)
-			if cb.cb_id = !init_state then
-				init_state := cb_sub.cb_id;
-			loop cb_sub (current_el @ el)
 		| NextSub (bb_sub,bb_next) ->
 			let next_state_id = loop bb_next [] in
 			let sub_state_id = loop bb_sub [] in
@@ -425,4 +423,4 @@ let block_to_texpr_coroutine ctx cb cont cls tf_args forbidden_vars exprs p =
 		etry
 	in
 
-	eloop, eif_error, !init_state, fields |> Hashtbl.to_seq_values |> List.of_seq
+	eloop, eif_error, init_state, fields |> Hashtbl.to_seq_values |> List.of_seq

--- a/src/coro/coroTypes.ml
+++ b/src/coro/coroTypes.ml
@@ -60,3 +60,4 @@ type cb_flag =
 	| CbEmptyMarked
 	| CbForwardMarked
 	| CbReindexed
+	| CbGenerated

--- a/src/coro/coroTypes.ml
+++ b/src/coro/coroTypes.ml
@@ -5,7 +5,7 @@ type coro_block = {
 	mutable cb_id : int;
 	cb_el : texpr DynArray.t;
 	cb_typepos : (Type.t * pos) option;
-	cb_catch : coro_block option;
+	mutable cb_catch : coro_block option;
 	mutable cb_next : coro_next;
 	mutable cb_flags : int;
 }

--- a/src/coro/coroTypes.ml
+++ b/src/coro/coroTypes.ml
@@ -2,11 +2,12 @@ open Globals
 open Type
 
 type coro_block = {
-	cb_id : int;
+	mutable cb_id : int;
 	cb_el : texpr DynArray.t;
 	cb_typepos : (Type.t * pos) option;
 	cb_catch : coro_block option;
 	mutable cb_next : coro_next;
+	mutable cb_flags : int;
 }
 
 and coro_next =
@@ -54,3 +55,8 @@ type coro_ctx = {
 	mutable current_catch : coro_block option;
 	mutable has_catch : bool;
 }
+
+type cb_flag =
+	| CbEmptyMarked
+	| CbForwardMarked
+	| CbReindexed


### PR DESCRIPTION
This moves some optimizations from the texpr transformer to the graph structure, which is just all around better. Of course, some graphs are in order:

mapCalls before:

![mapCalls_before](https://github.com/user-attachments/assets/9f64c5af-d3bf-403a-a94e-060a09e0ac7d)

mapCalls after:

![mapCalls_after](https://github.com/user-attachments/assets/26a12b6b-d922-4508-8764-4d6249910291)

By eliminating forwarding states 4 and 6, both 3 and 5 go directly to 9. This was already the case for the output, but now we can make dot graphs, too.

suspendOneWayOrAnother before:

![oneWayOrAnother_before](https://github.com/user-attachments/assets/78c347c7-8b53-4821-a509-94632f26003a)

suspendOneWayOrAnother after:

![oneWayOrAnother_after](https://github.com/user-attachments/assets/251c54d7-8e26-4ab0-ad67-ab24a4f2f326)

This is the case I want to detect in #44.

I also tried reindexing all block IDs so that the generated states are sequential, but that caused some failures in the exception tests that I have yet to figure out. I'd like to do this because it looks better, and at least JVM can use a different instruction for "tight switches" instead of ones where the values are more spread out.

Also, this currently breaks python, php and cpp, so there's more things to address.