### PR TITLE
Implement tail-call optimization

### DIFF
--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -765,6 +765,7 @@ let create timer_ctx compilation_step cs version args display_mode =
 				base_continuation_class = null_class;
 				continuation_result = (fun _ -> die "Could not locate class ContinuationResult<T> (was it redefined?)" __LOC__);
 				continuation_result_class = null_class;
+				immediate_continuation_result_class = null_class;
 				control = mk_mono();
 			}
 		};
@@ -904,6 +905,7 @@ let clone com is_macro_context =
 				base_continuation_class = null_class;
 				continuation_result = (fun _ -> die "Could not locate class ContinuationResult<T> (was it redefined?)" __LOC__);
 				continuation_result_class = null_class;
+				immediate_continuation_result_class = null_class;
 				control = mk_mono();
 			};
 		};

--- a/src/core/tType.ml
+++ b/src/core/tType.ml
@@ -480,6 +480,7 @@ type coro_types = {
 	mutable base_continuation_class : tclass;
 	mutable continuation_result : t -> t;
 	mutable continuation_result_class : tclass;
+	mutable immediate_continuation_result_class : tclass;
 	mutable control : t;
 }
 

--- a/src/coro/contTypes.ml
+++ b/src/coro/contTypes.ml
@@ -8,9 +8,13 @@ type continuation_api = {
 	context : tclass_field;
 	state : tclass_field;
 	recursing : tclass_field;
+	immediate_result : texpr -> texpr;
+	immediate_error : texpr -> Type.t -> texpr;
 }
 
-let create_continuation_api control result error completion context state recursing = {
+let create_continuation_api immediate_result immediate_error control result error completion context state recursing = {
+	immediate_result;
+	immediate_error;
 	control;
 	result;
 	error;

--- a/src/coro/coro.ml
+++ b/src/coro/coro.ml
@@ -97,7 +97,17 @@ module ContinuationClassBuilder = struct
 				let cf_context    = PMap.find "_hx_context" basic.tcoro.base_continuation_class.cl_fields in
 				let cf_state      = PMap.find "_hx_state" basic.tcoro.base_continuation_class.cl_fields in
 				let cf_recursing  = PMap.find "_hx_recursing" basic.tcoro.base_continuation_class.cl_fields in
-				let api = ContTypes.create_continuation_api cf_control cf_result cf_error cf_completion cf_context cf_state cf_recursing in
+				let immediate_result,immediate_error =
+					let c = basic.tcoro.immediate_continuation_result_class in
+					let cf_result = PMap.find "withResult" c.cl_statics in
+					let cf_error = PMap.find "withError" c.cl_statics in
+					(fun e ->
+						CallUnification.make_static_call_better ctx.typer c cf_result [e.etype] [e] (TInst(c,[e.etype])) null_pos
+					), (fun e t ->
+						CallUnification.make_static_call_better ctx.typer c cf_error [] [e] (TInst(c,[t])) null_pos
+					)
+				in
+				let api = ContTypes.create_continuation_api immediate_result immediate_error cf_control cf_result cf_error cf_completion cf_context cf_state cf_recursing in
 				ctx.typer.g.continuation_api <- Some api;
 				api
 		in
@@ -229,64 +239,27 @@ module ContinuationClassBuilder = struct
 		field
 end
 
-let fun_to_coro ctx coro_type =
+let create_continuation_class ctx coro_class initial_state =
+	let ctor   = ContinuationClassBuilder.mk_ctor ctx coro_class initial_state in
+	let resume = ContinuationClassBuilder.mk_invoke_resume ctx coro_class in
+	TClass.add_field coro_class.cls resume;
+	Option.may (TClass.add_field coro_class.cls) coro_class.captured;
+	coro_class.cls.cl_constructor <- Some ctor;
+	if ctx.coro_debug then
+		Printer.s_tclass "\t" coro_class.cls |> Printf.printf "%s\n";
+
+	ctx.typer.m.curmod.m_types <- ctx.typer.m.curmod.m_types @ [ TClassDecl coro_class.cls ]
+
+let coro_to_state_machine ctx coro_class cb_root exprs args vcompletion vcontinuation =
 	let basic = ctx.typer.t in
-
-	let mk_assign estate eid =
-		mk (TBinop (OpAssign,estate,eid)) eid.etype null_pos
-	in
-
-	let coro_class = ContinuationClassBuilder.create ctx coro_type in
-	let cont = coro_class.continuation_api in
-
-	(* Generate and assign the continuation variable *)
-	let vcompletion = alloc_var VGenerated "_hx_completion" basic.tcoro.continuation null_pos in
-	let ecompletion = Builder.make_local vcompletion null_pos in
-
-	let vcontinuation = alloc_var VGenerated "_hx_continuation" coro_class.outside.cls_t null_pos in
-	let econtinuation = Builder.make_local vcontinuation null_pos in
-
-	let continuation_field cf t =
-		mk (TField(econtinuation,FInstance(coro_class.cls, coro_class.outside.param_types, cf))) t null_pos
-	in
-
-	let estate  = continuation_field cont.state basic.tint in
-	let econtrol = continuation_field cont.control basic.tcoro.control in
-	let eresult = continuation_field cont.result basic.tany in
-	let eerror = continuation_field cont.error basic.texception in
-
-	let expr, args, pe =
-		match coro_type with
-		| ClassField (_, cf, f, p) ->
-			f.tf_expr, f.tf_args, p
-		| LocalFunc(f,_) ->
-			f.tf_expr, f.tf_args, f.tf_expr.epos
-		in
-
-	let cb_root = make_block ctx (Some(expr.etype, null_pos)) in
-
-	ignore(CoroFromTexpr.expr_to_coro ctx eresult cb_root expr);
-	let cb_root = CoroFromTexpr.optimize_cfg ctx cb_root in
-	let exprs = {CoroToTexpr.econtinuation;ecompletion;econtrol;eresult;estate;eerror} in
+	let cont = coro_class.ContinuationClassBuilder.continuation_api in
 	let eloop, eif_error, initial_state, fields = CoroToTexpr.block_to_texpr_coroutine ctx cb_root cont coro_class.cls args [ vcompletion.v_id; vcontinuation.v_id ] exprs null_pos in
 	(* update cf_type to use inside type parameters *)
 	List.iter (fun cf ->
 		cf.cf_type <- substitute_type_params coro_class.type_param_subst cf.cf_type;
 		TClass.add_field coro_class.cls cf
 	) fields;
-	let ctor   = ContinuationClassBuilder.mk_ctor ctx coro_class initial_state in
-	let resume = ContinuationClassBuilder.mk_invoke_resume ctx coro_class in
-
-	TClass.add_field coro_class.cls resume;
-	Option.may (TClass.add_field coro_class.cls) coro_class.captured;
-
-	coro_class.cls.cl_constructor <- Some ctor;
-
-	if ctx.coro_debug then
-		Printer.s_tclass "\t" coro_class.cls |> Printf.printf "%s\n";
-
-	ctx.typer.m.curmod.m_types <- ctx.typer.m.curmod.m_types @ [ TClassDecl coro_class.cls ];
-
+	create_continuation_class ctx coro_class initial_state;
 	let continuation_var = mk (TVar (vcontinuation, Some (Builder.make_null coro_class.outside.cls_t null_pos))) coro_class.outside.cls_t null_pos in
 
 	let std_is e t =
@@ -303,6 +276,12 @@ let fun_to_coro ctx coro_type =
 		| LocalFunc(f,v) ->
 			[ Builder.make_local v null_pos ]
 	in
+
+	let mk_assign eto efrom =
+		mk (TBinop (OpAssign,eto,efrom)) efrom.etype null_pos
+	in
+
+	let {CoroToTexpr.econtinuation;ecompletion;econtrol;eresult;estate;eerror} = exprs in
 
 	let continuation_assign =
 		let t = coro_class.outside.cls_t in
@@ -325,7 +304,10 @@ let fun_to_coro ctx coro_type =
 		mk (TIf (tcond, tif, Some telse)) basic.tvoid null_pos
 	in
 
-	let tf_expr = mk (TBlock [
+	let continuation_field cf t =
+		mk (TField(econtinuation,FInstance(coro_class.cls, coro_class.outside.param_types, cf))) t null_pos
+	in
+	mk (TBlock [
 		continuation_var;
 		continuation_assign;
 		mk_assign
@@ -333,7 +315,161 @@ let fun_to_coro ctx coro_type =
 			(mk (TConst (TBool true)) basic.tbool null_pos);
 		eloop;
 		Builder.mk_return (Builder.make_null basic.tany null_pos);
-	]) basic.tvoid null_pos in
+	]) basic.tvoid null_pos
+
+let coro_to_normal ctx coro_class cb_root exprs vcontinuation =
+	let open ContinuationClassBuilder in
+	let open CoroToTexpr in
+	let basic = ctx.typer.t in
+	create_continuation_class ctx coro_class 0;
+	let rec loop cb previous_el =
+		let p = null_pos in
+		let loop_as_block cb =
+			let el,term = loop cb [] in
+			mk (TBlock el) basic.tvoid p,term
+		in
+		let current_el = ref (previous_el @ (get_block_exprs cb)) in
+		let continue cb_next e =
+			loop cb_next (!current_el @ [e])
+		in
+		let maybe_continue cb_next term e =
+			if not term then
+				continue cb_next e
+			else
+				(!current_el @ [e]),true
+		in
+		let add e = current_el := !current_el @ [e] in
+		let terminate e =
+			add e;
+			!current_el,true
+		in
+		begin match cb.cb_next with
+			| NextSub(cb_sub,cb_next) ->
+				let e_next,term = loop_as_block cb_sub in
+				maybe_continue cb_next term e_next
+			| NextReturn e1 ->
+				let e1 = coro_class.continuation_api.immediate_result e1 in
+				terminate ((mk (TReturn (Some e1)) t_dynamic p));
+			| NextThrow e1 ->
+				let e1 = coro_class.continuation_api.immediate_error e1 coro_class.inside.result_type in
+				terminate ((mk (TReturn (Some e1)) t_dynamic p));
+			| NextUnknown | NextReturnVoid ->
+				let e1 = coro_class.continuation_api.immediate_result (mk (TConst TNull) t_dynamic null_pos) in
+				terminate ((mk (TReturn (Some e1)) t_dynamic p));
+			| NextBreak _ ->
+				terminate (mk TBreak t_dynamic p);
+			| NextContinue _ ->
+				terminate (mk TContinue t_dynamic p);
+			| NextIfThen(e1,cb_then,cb_next) ->
+				let e_then,_ = loop_as_block cb_then in
+				let e_if = mk (TIf(e1,e_then,None)) basic.tvoid p in
+				continue cb_next e_if
+			| NextIfThenElse(e1,cb_then,cb_else,cb_next) ->
+				let e_then,term_then = loop_as_block cb_then in
+				let e_else,term_else = loop_as_block cb_else in
+				let e_if = mk (TIf(e1,e_then,Some e_else)) basic.tvoid p in
+				maybe_continue cb_next (term_then && term_else) e_if
+			| NextSwitch(switch,cb_next) ->
+				let term = ref true in
+				let switch_cases = List.map (fun (el,cb) ->
+					let e,term' = loop_as_block cb in
+					term := !term && term';
+					{
+					case_patterns = el;
+					case_expr = e;
+				}) switch.cs_cases in
+				let switch_default = Option.map (fun cb ->
+					let e,term' = loop_as_block cb in
+					term := !term && term';
+					e
+				) switch.cs_default in
+				let switch = {
+					switch_subject = switch.cs_subject;
+					switch_cases;
+					switch_default;
+					switch_exhaustive = switch.cs_exhaustive
+				} in
+				maybe_continue cb_next (switch.switch_exhaustive && !term) (mk (TSwitch switch) basic.tvoid p)
+			| NextWhile(e1,cb_body,cb_next) ->
+				let e_body,_ = loop_as_block cb_body in
+				let e_while = mk (TWhile(e1,e_body,NormalWhile)) basic.tvoid p in
+				continue cb_next e_while
+			| NextTry(cb_try,catches,cb_next) ->
+				let e_try,term = loop_as_block cb_try in
+				let term = ref term in
+				let catches = List.map (fun (v,cb) ->
+					let e,term' = loop_as_block cb in
+					term := !term && term';
+					(v,e)
+				) catches.cc_catches in
+				let e_try = mk (TTry(e_try,catches)) basic.tvoid p in
+				maybe_continue cb_next !term e_try
+			| NextFallThrough _ | NextGoto _ ->
+				!current_el,false
+			| NextSuspend(suspend,cb_next) ->
+				let e_sus = CoroToTexpr.make_suspending_call basic suspend exprs.ecompletion in
+				add (mk (TReturn (Some e_sus)) t_dynamic p);
+				!current_el,true
+		end
+	in
+	let el,_ = loop cb_root [] in
+	let e = mk (TBlock el) basic.tvoid null_pos in
+	let e = if ctx.nothrow then
+		e
+	else begin
+		let catch =
+			let v = alloc_var VGenerated "e" t_dynamic null_pos in
+			let ev = mk (TLocal v) v.v_type null_pos in
+			let eerr = coro_class.continuation_api.immediate_error ev coro_class.inside.result_type in
+			let eret = mk (TReturn (Some eerr)) t_dynamic null_pos in
+			(v,eret)
+		in
+		mk (TTry(e,[catch])) basic.tvoid null_pos
+	end in
+	mk (TBlock [
+		e
+	]) basic.tvoid null_pos
+
+let fun_to_coro ctx coro_type =
+	let basic = ctx.typer.t in
+
+	let coro_class = ContinuationClassBuilder.create ctx coro_type in
+	let cont = coro_class.continuation_api in
+
+	(* Generate and assign the continuation variable *)
+	let vcompletion = alloc_var VGenerated "_hx_completion" basic.tcoro.continuation null_pos in
+	let ecompletion = Builder.make_local vcompletion null_pos in
+
+	let vcontinuation = alloc_var VGenerated "_hx_continuation" coro_class.outside.cls_t null_pos in
+	let econtinuation = Builder.make_local vcontinuation null_pos in
+
+	let continuation_field cf t =
+		mk (TField(econtinuation,FInstance(coro_class.cls, coro_class.outside.param_types, cf))) t null_pos
+	in
+
+	let estate  = continuation_field cont.state basic.tint in
+	let econtrol = continuation_field cont.control basic.tcoro.control in
+	let eresult = continuation_field cont.result basic.tany in
+	let eerror = continuation_field cont.error basic.texception in
+
+	let expr, args, pe, name =
+		match coro_type with
+		| ClassField (_, cf, f, p) ->
+			f.tf_expr, f.tf_args, p, cf.cf_name
+		| LocalFunc(f,v) ->
+			f.tf_expr, f.tf_args, f.tf_expr.epos, v.v_name
+		in
+
+	let cb_root = make_block ctx (Some(expr.etype, null_pos)) in
+
+	ignore(CoroFromTexpr.expr_to_coro ctx eresult cb_root expr);
+	let exprs = {CoroToTexpr.econtinuation;ecompletion;econtrol;eresult;estate;eerror} in
+	let tf_expr,cb_root = try
+		let cb_root = CoroFromTexpr.optimize_cfg ctx cb_root in
+		coro_to_state_machine ctx coro_class cb_root exprs args vcompletion vcontinuation,cb_root
+	with CoroTco cb_root ->
+		coro_to_normal ctx coro_class cb_root exprs vcontinuation,cb_root
+	in
 
 	let tf_args = args @ [ (vcompletion,None) ] in
 	(* I'm not sure what this should be, but let's stick to the widest one for now.
@@ -342,7 +478,7 @@ let fun_to_coro ctx coro_type =
 	let tf_type = basic.tcoro.continuation_result coro_class.outside.result_type in
 	if ctx.coro_debug then begin
 		print_endline ("BEFORE:\n" ^ (s_expr_debug expr));
-		CoroDebug.create_dotgraph (DotGraph.get_dump_path (SafeCom.of_com ctx.typer.com) ([],pe.pfile) (Printf.sprintf "pos_%i" pe.pmin)) cb_root
+		CoroDebug.create_dotgraph (DotGraph.get_dump_path (SafeCom.of_com ctx.typer.com) (ctx.typer.c.curclass.cl_path) name) cb_root
 	end;
 	let e = mk (TFunction {tf_args; tf_expr; tf_type}) (TFun (tf_args |> List.map (fun (v, _) -> (v.v_name, false, v.v_type)), tf_type)) pe in
 	if ctx.coro_debug then print_endline ("AFTER:\n" ^ (s_expr_debug e));
@@ -352,6 +488,8 @@ let create_coro_context typer meta =
 	let ctx = {
 		typer;
 		coro_debug = Meta.has (Meta.Custom ":coroutine.debug") meta;
+		allow_tco = not (Meta.has (Meta.Custom ":coroutine.notco") meta);
+		nothrow = Meta.has (Meta.Custom ":coroutine.nothrow") meta;
 		vthis = None;
 		next_block_id = 0;
 		cb_unreachable = Obj.magic "";

--- a/src/coro/coroDebug.ml
+++ b/src/coro/coroDebug.ml
@@ -4,7 +4,7 @@ open Type
 
 let create_dotgraph path cb =
 	print_endline (String.concat "." path);
-	let ch,close = DotGraph.start_graph path "coro" in
+	let ch,close = DotGraph.start_graph path ".coro" in
 	let pctx = print_context() in
 	let st = s_type pctx in
 	let se = s_expr_pretty true "" false st in

--- a/src/coro/coroFromTexpr.ml
+++ b/src/coro/coroFromTexpr.ml
@@ -247,6 +247,8 @@ let expr_to_coro ctx eresult cb_root e =
 			let cb_next = make_block None in
 			let catches = List.map (fun (v,e) ->
 				let cb_catch = block_from_e e in
+				(* If we ever want to have TCO in functions with try/catch we'll have to handle this differently
+				   because there's no eresult in such cases. *)
 				add_expr cb_catch (mk (TVar(v,Some eresult)) ctx.typer.t.tvoid null_pos);
 				let cb_catch_next,_ = loop_block cb_catch ret e in
 				fall_through cb_catch_next cb_next;
@@ -366,6 +368,28 @@ let optimize_cfg ctx cb =
 			cb
 	in
 	let cb = loop cb in
+	let is_empty_termination_block cb =
+		DynArray.empty cb.cb_el && match cb.cb_next with
+			| NextReturnVoid | NextUnknown ->
+				true
+			| _ ->
+				false
+	in
+	let rec loop cb =
+		if not (has_block_flag cb CbTcoChecked) then begin
+			add_block_flag cb CbTcoChecked;
+			begin match cb.cb_next with
+			| NextSuspend(_,cb_next) ->
+				if not (is_empty_termination_block cb_next) then
+					raise Exit;
+			| _ ->
+				()
+			end;
+			coro_iter loop cb;
+		end
+	in
+	if ctx.allow_tco && not ctx.has_catch then
+		(try loop cb; raise (CoroTco cb) with Exit -> ());
 	(* third pass: reindex cb_id for tighter switches. Breadth-first because that makes the numbering more natural, maybe. *)
 	let i = ref 0 in
 	let queue = Queue.create () in

--- a/src/coro/coroFunctions.ml
+++ b/src/coro/coroFunctions.ml
@@ -20,6 +20,21 @@ let add_block_flag cb (flag : cb_flag) =
 let has_block_flag cb (flag : cb_flag) =
 	has_flag cb.cb_flags (Obj.magic flag)
 
+let get_block_exprs cb =
+	let rec loop idx acc =
+	if idx < 0 then
+		acc
+	else begin
+		let acc = match DynArray.unsafe_get cb.cb_el idx with
+			| {eexpr = TBlock el} ->
+				el @ acc
+			| e ->
+				e :: acc
+		in
+		loop (idx - 1) acc
+	end in
+	loop (DynArray.length cb.cb_el - 1) []
+
 let coro_iter f cb =
 	Option.may f cb.cb_catch;
 	match cb.cb_next with

--- a/src/coro/coroToTexpr.ml
+++ b/src/coro/coroToTexpr.ml
@@ -21,6 +21,19 @@ type coro_to_texpr_exprs = {
 
 let mk_int com i = Texpr.Builder.make_int com.Common.basic i null_pos
 
+let make_suspending_call basic call econtinuation =
+	(* lose Coroutine<T> type for the called function not to confuse further filters and generators *)
+	let tfun = match follow_with_coro call.cs_fun.etype with
+		| Coro (args, ret) ->
+			let args,ret = Common.expand_coro_type basic args ret in
+			TFun (args, ret)
+		| NotCoro _ ->
+			die "Unexpected coroutine type" __LOC__
+	in
+	let efun = { call.cs_fun with etype = tfun } in
+	let args = call.cs_args @ [ econtinuation ] in
+	mk (TCall (efun, args)) (basic.tcoro.continuation_result basic.tany) call.cs_pos
+
 let block_to_texpr_coroutine ctx cb cont cls tf_args forbidden_vars exprs p =
 	let {econtinuation;ecompletion;econtrol;eresult;estate;eerror} = exprs in
 	let open Texpr.Builder in
@@ -45,24 +58,13 @@ let block_to_texpr_coroutine ctx cb cont cls tf_args forbidden_vars exprs p =
 
 	let ereturn = mk (TReturn (Some econtinuation)) econtinuation.etype p in
 
-
 	let cb_uncaught = CoroFunctions.make_block ctx None in
 	let mk_suspending_call call =
 		let p = call.cs_pos in
 		let base_continuation_field_on e cf t =
 			mk (TField(e,FInstance(com.basic.tcoro.continuation_result_class, [com.basic.tany], cf))) t null_pos
 		in
-		(* lose Coroutine<T> type for the called function not to confuse further filters and generators *)
-		let tfun = match follow_with_coro call.cs_fun.etype with
-			| Coro (args, ret) ->
-				let args,ret = Common.expand_coro_type com.basic args ret in
-				TFun (args, ret)
-			| NotCoro _ ->
-				die "Unexpected coroutine type" __LOC__
-		in
-		let efun = { call.cs_fun with etype = tfun } in
-		let args = call.cs_args @ [ econtinuation ] in
-		let ecreatecoroutine = mk (TCall (efun, args)) (com.basic.tcoro.continuation_result com.basic.tany) call.cs_pos in
+		let ecreatecoroutine = make_suspending_call com.basic call econtinuation in
 
 		let vcororesult = alloc_var VGenerated "_hx_tmp" (com.basic.tcoro.continuation_result com.basic.tany) p in
 		let ecororesult = make_local vcororesult p in
@@ -102,21 +104,6 @@ let block_to_texpr_coroutine ctx cb cont cls tf_args forbidden_vars exprs p =
 			die "" __LOC__
 	in
 	let exc_state_map = Array.init ctx.next_block_id (fun _ -> ref []) in
-	let get_block_exprs cb =
-		let rec loop idx acc =
-		if idx < 0 then
-			acc
-		else begin
-			let acc = match DynArray.unsafe_get cb.cb_el idx with
-				| {eexpr = TBlock el} ->
-					el @ acc
-				| e ->
-					e :: acc
-			in
-			loop (idx - 1) acc
-		end in
-		loop (DynArray.length cb.cb_el - 1) []
-	in
 	let generate cb =
 		assert (cb != ctx.cb_unreachable);
 		let el = get_block_exprs cb in
@@ -363,13 +350,17 @@ let block_to_texpr_coroutine ctx cb cont cls tf_args forbidden_vars exprs p =
 
 	let eloop = mk (TWhile (make_bool com.basic true p, eswitch, NormalWhile)) com.basic.tvoid p in
 
-	let etry = mk (TTry (
-		eloop,
-		[
-			let vcaught = alloc_var VGenerated "e" t_dynamic null_pos in
-			(vcaught,assign eresult (make_local vcaught null_pos))
-		]
-	)) com.basic.tvoid null_pos in
+	let etry = if ctx.nothrow then
+		eloop
+	else
+		mk (TTry (
+			eloop,
+			[
+				let vcaught = alloc_var VGenerated "e" t_dynamic null_pos in
+				(vcaught,assign eresult (make_local vcaught null_pos))
+			]
+		)) com.basic.tvoid null_pos
+	in
 
 	let eexchandle =
 		let cases = DynArray.create () in

--- a/src/coro/coroTypes.ml
+++ b/src/coro/coroTypes.ml
@@ -49,6 +49,8 @@ and coro_suspend = {
 type coro_ctx = {
 	typer : Typecore.typer;
 	coro_debug : bool;
+	allow_tco : bool;
+	nothrow : bool;
 	mutable vthis : tvar option;
 	mutable next_block_id : int;
 	mutable cb_unreachable : coro_block;
@@ -59,5 +61,8 @@ type coro_ctx = {
 type cb_flag =
 	| CbEmptyMarked
 	| CbForwardMarked
+	| CbTcoChecked
 	| CbReindexed
 	| CbGenerated
+
+exception CoroTco of coro_block

--- a/src/typing/typerEntry.ml
+++ b/src/typing/typerEntry.ml
@@ -168,6 +168,13 @@ let load_coro ctx =
 		| _ ->
 			()
 	) m.m_types;
+	let m = TypeloadModule.load_module ctx (["haxe";"coro"],"ImmediateContinuationResult") null_pos in
+	List.iter (function
+		| TClassDecl({ cl_path = (["haxe";"coro"], "ImmediateContinuationResult") } as cl) ->
+			ctx.t.tcoro.immediate_continuation_result_class <- cl;
+		| _ ->
+			()
+	) m.m_types;
 	let m = TypeloadModule.load_module ctx (["haxe";"coro"],"ContinuationControl") null_pos in
 	List.iter (function
 		| TAbstractDecl({a_path = (["haxe";"coro"],"ContinuationControl")} as a) ->

--- a/std/haxe/coro/Coroutine.hx
+++ b/std/haxe/coro/Coroutine.hx
@@ -30,13 +30,13 @@ abstract Coroutine<T:haxe.Constraints.Function> {
 		return cast _hx_continuation;
 	}
 
-	@:coroutine public static function delay(ms:Int):Void {
+	@:coroutine @:coroutine.nothrow public static function delay(ms:Int):Void {
 		Coroutine.suspend(cont -> {
 			cont._hx_context.scheduler.scheduleIn(() -> cont.resume(null, null), ms);
 		});
 	}
 
-	@:coroutine public static function yield():Void {
+	@:coroutine @:coroutine.nothrow public static function yield():Void {
 		Coroutine.suspend(cont -> {
 			cont._hx_context.scheduler.schedule(() -> cont.resume(null, null));
 		});

--- a/std/haxe/coro/ImmediateContinuationResult.hx
+++ b/std/haxe/coro/ImmediateContinuationResult.hx
@@ -1,0 +1,23 @@
+package haxe.coro;
+
+import haxe.Exception;
+
+class ImmediateContinuationResult<T> extends ContinuationResult<T> {
+	function new(result:T, error:Exception) {
+		_hx_result = result;
+		_hx_error = error;
+		_hx_control = error == null ? Returned : Thrown;
+	}
+
+	static public function withResult<T>(result:T) {
+		return new ImmediateContinuationResult(result, null);
+	}
+
+	static public function withError<T>(error:T) {
+		return new ImmediateContinuationResult<T>(null, @:privateAccess haxe.Exception.thrown(error));
+	}
+
+	public override function toString() {
+		return '[ImmediateContinuationResult ${_hx_control.toString()}, $_hx_result]';
+	}
+}


### PR DESCRIPTION
This detects when all our suspend calls are in tail position and then skips generating the state machine:

```haxe
@:coroutine function suspendOneWayOrAnother() {
	return if (Math.random() > 0.5) {
		Coroutine.delay(100);
	} else {
		Coroutine.yield();
	}
}
```

Generated:

```js
function Main_suspendOneWayOrAnother(_hx_completion) {
	if(Math.random() > 0.5) {
		return haxe_coro_Coroutine.delay(100,_hx_completion);
	} else {
		return haxe_coro_Coroutine.yield(_hx_completion);
	}
}
```

`delay` and `yield` are now generated like this:

```js
	static delay(ms,_hx_completion) {
		return haxe_coro_Coroutine.suspend(function(cont) {
			cont._hx_context.scheduler.scheduleIn(function() {
				cont.resume(null,null);
			},ms);
		},_hx_completion);
	}
	static yield(_hx_completion) {
		return haxe_coro_Coroutine.suspend(function(cont) {
			cont._hx_context.scheduler.schedule(function() {
				cont.resume(null,null);
			});
		},_hx_completion);
	}
```

That's the good news. The bad news is that this is where we get punished for our `_hx_control` approach in cases if plain value returns. That is, a simple coroutine like this:

```haxe
@:coroutine function simple() {
	return "foo";
}
```

Has to return an instance of ContinuationResult, not just a value. I've made it generate this:

```js
function Main_simple(_hx_completion) {
	return haxe_coro_ImmediateContinuationResult.withResult("foo");
}
```

The `throw` version is analogous:

```js
function Main_simple(_hx_completion) {
	return haxe_coro_ImmediateContinuationResult.withError("foo");
}
```

My take on this is that it's preferable to optimize for real world cases, which usually have at least some suspension point.

-------------

There are two TODOs:

1. Exception handling: The normal version currently doesn't catch exceptions, which means they can escape in cases like this:

```haxe
function throwSomething() {
	throw "foo";
}

@:coroutine function simple() {
	throwSomething();
}
```

I'd like to stick to the exception-free approach, so we'll have to catch this.

2. There is some awkwardness due to the interpretation of what blocks terminate. The initial example actually generates this intermittently:

```haxe
function(_hx_completion:haxe.coro.IContinuation<Any>) {
        {
                if (Math.random() > 0.5) {
                        return haxe.coro._Coroutine.Coroutine_Impl_.delay(100, _hx_completion);
                } else {
                        return haxe.coro._Coroutine.Coroutine_Impl_.yield(_hx_completion);
                };
                return haxe.coro.ImmediateContinuationResult.withResult(null);
        };
  }
```

That extra return is there because to the transformer, the suspension calls are not terminators. They only become terminators when we generate the texpr, so think we have to keep track of block termination status there.

Notably, the reason this happens is because the compiler already transforms the expression to this before it even arrives at the coro transformer:

```haxe
                if (Math.random() > 0.5) {
                        haxe.coro._Coroutine.Coroutine_Impl_.delay(100);
                } else {
                        haxe.coro._Coroutine.Coroutine_Impl_.yield();
                };
                return;
```

This is because both `delay` and `yield` are `Void` functions, and the compiler wants to avoid a `return Void` situation.