### PR TITLE
Add _hx_tmp local to deal with intermediate values

### DIFF
--- a/src/coro/coro.ml
+++ b/src/coro/coro.ml
@@ -255,6 +255,9 @@ let fun_to_coro ctx coro_type =
 	let eresult = continuation_field cont.result basic.tany in
 	let eerror = continuation_field cont.error basic.texception in
 
+	let vtmp = alloc_var VGenerated "_hx_tmp" basic.tany null_pos in
+	let etmp = mk (TLocal vtmp) vtmp.v_type null_pos in
+
 	let expr, args, pe =
 		match coro_type with
 		| ClassField (_, cf, f, p) ->
@@ -265,9 +268,9 @@ let fun_to_coro ctx coro_type =
 
 	let cb_root = make_block ctx (Some(expr.etype, null_pos)) in
 
-	ignore(CoroFromTexpr.expr_to_coro ctx eresult cb_root expr);
+	ignore(CoroFromTexpr.expr_to_coro ctx etmp cb_root expr);
 	let cb_root = CoroFromTexpr.optimize_cfg ctx cb_root in
-	let exprs = {CoroToTexpr.econtinuation;ecompletion;econtrol;eresult;estate;eerror} in
+	let exprs = {CoroToTexpr.econtinuation;ecompletion;econtrol;eresult;estate;eerror;etmp} in
 	let eloop, eif_error, initial_state, fields = CoroToTexpr.block_to_texpr_coroutine ctx cb_root cont coro_class.cls args [ vcompletion.v_id; vcontinuation.v_id ] exprs null_pos in
 	(* update cf_type to use inside type parameters *)
 	List.iter (fun cf ->
@@ -331,6 +334,7 @@ let fun_to_coro ctx coro_type =
 		mk_assign
 			(continuation_field cont.recursing basic.tbool)
 			(mk (TConst (TBool true)) basic.tbool null_pos);
+		mk (TVar(vtmp,Some eresult)) vtmp.v_type null_pos;
 		eloop;
 		Builder.mk_return (Builder.make_null basic.tany null_pos);
 	]) basic.tvoid null_pos in

--- a/src/coro/coroFromTexpr.ml
+++ b/src/coro/coroFromTexpr.ml
@@ -11,7 +11,7 @@ type coro_ret =
 	| RValue
 	| RBlock
 
-let expr_to_coro ctx eresult cb_root e =
+let expr_to_coro ctx etmp cb_root e =
 	let ordered_value_marker = ref false in
 	let start_ordered_value_list () =
 		let old = !ordered_value_marker in
@@ -151,7 +151,7 @@ let expr_to_coro ctx eresult cb_root e =
 							cs_pos = e.epos
 						} in
 						terminate cb (NextSuspend(suspend,cb_next)) t_dynamic null_pos;
-						cb_next,eresult
+						cb_next,etmp
 					| _ ->
 						cb,{e with eexpr = TCall(e1,el)}
 					end
@@ -247,7 +247,7 @@ let expr_to_coro ctx eresult cb_root e =
 			let cb_next = make_block None in
 			let catches = List.map (fun (v,e) ->
 				let cb_catch = block_from_e e in
-				add_expr cb_catch (mk (TVar(v,Some eresult)) ctx.typer.t.tvoid null_pos);
+				add_expr cb_catch (mk (TVar(v,Some etmp)) ctx.typer.t.tvoid null_pos);
 				let cb_catch_next,_ = loop_block cb_catch ret e in
 				fall_through cb_catch_next cb_next;
 				v,cb_catch

--- a/src/coro/coroToTexpr.ml
+++ b/src/coro/coroToTexpr.ml
@@ -17,12 +17,13 @@ type coro_to_texpr_exprs = {
 	eresult : texpr;
 	estate : texpr;
 	eerror : texpr;
+	etmp : texpr;
 }
 
 let mk_int com i = Texpr.Builder.make_int com.Common.basic i null_pos
 
 let block_to_texpr_coroutine ctx cb cont cls tf_args forbidden_vars exprs p =
-	let {econtinuation;ecompletion;econtrol;eresult;estate;eerror} = exprs in
+	let {econtinuation;ecompletion;econtrol;eresult;estate;eerror;etmp} = exprs in
 	let open Texpr.Builder in
 	let com = ctx.typer.com in
 
@@ -44,7 +45,6 @@ let block_to_texpr_coroutine ctx cb cont cls tf_args forbidden_vars exprs p =
 	in
 
 	let ereturn = mk (TReturn (Some econtinuation)) econtinuation.etype p in
-
 
 	let cb_uncaught = CoroFunctions.make_block ctx None in
 	let mk_suspending_call call =
@@ -73,9 +73,9 @@ let block_to_texpr_coroutine ctx cb cont cls tf_args forbidden_vars exprs p =
 			set_control CoroPending;
 			ereturn;
 		]) com.basic.tvoid p in
-		let ereturned = assign (base_continuation_field_on econtinuation cont.result com.basic.tany (* !!! *)) (base_continuation_field_on ecororesult cont.result com.basic.tany) in
+		let ereturned = assign etmp (base_continuation_field_on ecororesult cont.result com.basic.tany) in
 		let ethrown = mk (TBlock [
-			assign eresult (base_continuation_field_on ecororesult cont.error cont.error.cf_type);
+			assign etmp (base_continuation_field_on ecororesult cont.error cont.error.cf_type);
 			mk TBreak t_dynamic p;
 		]) com.basic.tvoid p in
 		let econtrol_switch = CoroControl.make_control_switch com.basic esubject esuspended ereturned ethrown p in
@@ -152,7 +152,7 @@ let block_to_texpr_coroutine ctx cb cont cls tf_args forbidden_vars exprs p =
 		| NextReturn e ->
 			add_state (Some (-1)) [ set_control CoroReturned; assign eresult e; ereturn ]
 		| NextThrow e1 ->
-			add_state None [ assign eresult e1; mk TBreak t_dynamic p ]
+			add_state None [ assign etmp e1; mk TBreak t_dynamic p ]
 		| NextSub (cb_sub,cb_next) ->
 			ignore(cb_next.cb_id);
 			add_state (Some cb_sub.cb_id) []
@@ -201,7 +201,7 @@ let block_to_texpr_coroutine ctx cb cont cls tf_args forbidden_vars exprs p =
 					| TDynamic _ ->
 						set_state cb_catch.cb_id (* no next *)
 					| t ->
-						let etypecheck = std_is eresult vcatch.v_type in
+						let etypecheck = std_is etmp vcatch.v_type in
 						mk (TIf (etypecheck, set_state cb_catch.cb_id, Some enext)) com.basic.tvoid null_pos
 				) erethrow (List.rev catch.cc_catches)
 			in
@@ -219,7 +219,7 @@ let block_to_texpr_coroutine ctx cb cont cls tf_args forbidden_vars exprs p =
 
 	let states = !states in
 	let rethrow_state_id = cb_uncaught.cb_id in
-	let rethrow_state = make_state rethrow_state_id [assign eresult eerror; mk TBreak t_dynamic p] in
+	let rethrow_state = make_state rethrow_state_id [assign etmp eerror; mk TBreak t_dynamic p] in
 	let states = states @ [rethrow_state] |> List.sort (fun state1 state2 -> state1.cs_id - state2.cs_id) in
 
 	let module IntSet = Set.Make(struct
@@ -335,7 +335,7 @@ let block_to_texpr_coroutine ctx cb cont cls tf_args forbidden_vars exprs p =
 			initial.cs_el <- assign :: initial.cs_el) tf_args;
 
 	let ethrow = mk (TBlock [
-		assign eresult (make_string com.basic "Invalid coroutine state" p);
+		assign etmp (make_string com.basic "Invalid coroutine state" p);
 		mk TBreak t_dynamic p
 	]) com.basic.tvoid null_pos
 	in
@@ -367,7 +367,7 @@ let block_to_texpr_coroutine ctx cb cont cls tf_args forbidden_vars exprs p =
 		eloop,
 		[
 			let vcaught = alloc_var VGenerated "e" t_dynamic null_pos in
-			(vcaught,assign eresult (make_local vcaught null_pos))
+			(vcaught,assign etmp (make_local vcaught null_pos))
 		]
 	)) com.basic.tvoid null_pos in
 
@@ -384,7 +384,7 @@ let block_to_texpr_coroutine ctx cb cont cls tf_args forbidden_vars exprs p =
 				DynArray.add cases {case_patterns = patterns; case_expr = expr};
 		) exc_state_map;
 		let el = [
-			assign eerror (wrap_thrown eresult);
+			assign eerror (wrap_thrown etmp);
 			set_control CoroThrown;
 			ereturn;
 		] in


### PR DESCRIPTION
Sorry for all the branches, this should settle down soon!

This introduces `var _hx_tmp = _hx_continuation._hx_result` at the coro start and uses that variable to transmit intermediate values. This keeps the actual `_hx_result` clean and only assigns to it when there's actually a result, much like how `_hx_error` is handled.

So if we have this:

```haxe
@:coroutine function stringToInt(s:String) {
	return Std.parseInt(s);
}

@:coroutine function intToString(i:Int) {
	return Std.string(i);
}

@:coroutine @:coroutine.debug function f() {
	try {
		return intToString(stringToInt("12"));
	} catch(e:Dynamic) {
		trace("oops", e);
		return "ret";
	}
}
```

We get this state machine for `f`:

```js
function Main_f(_hx_completion) {
	let _hx_continuation = null;
	if(((_hx_completion) instanceof _$Main_HxCoro_$_$Main_$f) && _hx_completion._hx_recursing == false) {
		_hx_continuation = _hx_completion;
		if(_hx_continuation._hx_error != null) {
			_hx_continuation._hx_state = 7;
		}
	} else {
		_hx_continuation = new _$Main_HxCoro_$_$Main_$f(_hx_completion);
	}
	_hx_continuation._hx_recursing = true;
	let _hx_tmp = _hx_continuation._hx_result;
	while(true) {
		try {
			_hx_loop2: while(true) switch(_hx_continuation._hx_state) {
			case 0:
				_hx_continuation._hx_state = 1;
				break;
			case 1:
				_hx_continuation._hx_state = 5;
				let _hx_tmp1 = Main_stringToInt("12",_hx_continuation);
				switch(_hx_tmp1._hx_control) {
				case 0:
					_hx_continuation._hx_control = 0;
					return _hx_continuation;
				case 1:
					_hx_tmp = _hx_tmp1._hx_result;
					break;
				case 2:
					_hx_tmp = _hx_tmp1._hx_error;
					break _hx_loop2;
				}
				break;
			case 2:
				_hx_continuation._hx_state = 3;
				break;
			case 3:
				_hx_continuation._hx_state = -1;
				let e = _hx_tmp;
				haxe_Log.trace("oops",{ fileName : "source/Main.hx", lineNumber : 15, className : "_Main.Main_Fields_", methodName : "f", customParams : [e]});
				_hx_continuation._hx_control = 1;
				_hx_continuation._hx_result = "ret";
				return _hx_continuation;
			case 4:
				_hx_continuation._hx_state = -1;
				_hx_continuation._hx_control = 1;
				return _hx_continuation;
			case 5:
				_hx_continuation._hx_state = 6;
				let _hx_tmp2 = Main_intToString(_hx_tmp,_hx_continuation);
				switch(_hx_tmp2._hx_control) {
				case 0:
					_hx_continuation._hx_control = 0;
					return _hx_continuation;
				case 1:
					_hx_tmp = _hx_tmp2._hx_result;
					break;
				case 2:
					_hx_tmp = _hx_tmp2._hx_error;
					break _hx_loop2;
				}
				break;
			case 6:
				_hx_continuation._hx_state = -1;
				_hx_continuation._hx_control = 1;
				_hx_continuation._hx_result = _hx_tmp;
				return _hx_continuation;
			case 7:
				_hx_tmp = _hx_continuation._hx_error;
				break _hx_loop2;
			default:
				_hx_tmp = "Invalid coroutine state";
				break _hx_loop2;
			}
		} catch( _g ) {
			_hx_tmp = haxe_Exception.caught(_g).unwrap();
		}
		switch(_hx_continuation._hx_state) {
		case 6:case 5:case 1:
			_hx_continuation._hx_state = 2;
			break;
		default:
			_hx_continuation._hx_error = haxe_Exception.thrown(_hx_tmp);
			_hx_continuation._hx_control = 2;
			return _hx_continuation;
		}
	}
}
```

The only assignments to `_hx_continuation._hx_result` are now in state 6 from the suspension call result, and in state 3 from the direct `return "ret"`.