### PR TITLE
Remove unreachable block

### DIFF
--- a/src/coro/coro.ml
+++ b/src/coro/coro.ml
@@ -333,10 +333,10 @@ let coro_to_normal ctx coro_class cb_root exprs vcontinuation =
 		let continue cb_next e =
 			loop cb_next (!current_el @ [e])
 		in
-		let maybe_continue cb_next term e =
-			if not term then
+		let maybe_continue cb_next term e = match cb_next with
+			| Some cb_next when not term ->
 				continue cb_next e
-			else
+			| _ ->
 				(!current_el @ [e]),true
 		in
 		let add e = current_el := !current_el @ [e] in
@@ -398,7 +398,7 @@ let coro_to_normal ctx coro_class cb_root exprs vcontinuation =
 			| NextWhile(e1,cb_body,cb_next) ->
 				let e_body,_ = loop_as_block cb_body in
 				let e_while = mk (TWhile(e1,e_body,NormalWhile)) basic.tvoid p in
-				continue cb_next e_while
+				maybe_continue cb_next false e_while
 			| NextTry(cb_try,catches,cb_next) ->
 				let e_try,term = loop_as_block cb_try in
 				let term = ref term in
@@ -501,9 +501,7 @@ let create_coro_context typer meta =
 		nothrow = Meta.has (Meta.Custom ":coroutine.nothrow") meta;
 		vthis = None;
 		next_block_id = 0;
-		cb_unreachable = Obj.magic "";
 		current_catch = None;
 		has_catch = false;
 	} in
-	ctx.cb_unreachable <- make_block ctx None;
 	ctx

--- a/src/coro/coro.ml
+++ b/src/coro/coro.ml
@@ -493,11 +493,12 @@ let fun_to_coro ctx coro_type =
 	e
 
 let create_coro_context typer meta =
+	let optimize = not (Define.raw_defined typer.Typecore.com.defines "coroutine.noopt") in
 	let ctx = {
 		typer;
 		coro_debug = Meta.has (Meta.Custom ":coroutine.debug") meta;
-		optimize = not (Define.raw_defined typer.com.defines ":coroutine.noopt");
-		allow_tco = not (Meta.has (Meta.Custom ":coroutine.notco") meta);
+		optimize;
+		allow_tco = optimize && not (Meta.has (Meta.Custom ":coroutine.notco") meta);
 		throw = Define.raw_defined typer.com.defines "coroutine.throw";
 		nothrow = Meta.has (Meta.Custom ":coroutine.nothrow") meta;
 		vthis = None;

--- a/src/coro/coro.ml
+++ b/src/coro/coro.ml
@@ -473,7 +473,7 @@ let fun_to_coro ctx coro_type =
 	ignore(CoroFromTexpr.expr_to_coro ctx etmp cb_root expr);
 	let exprs = {CoroToTexpr.econtinuation;ecompletion;econtrol;eresult;estate;eerror;etmp} in
 	let tf_expr,cb_root = try
-		let cb_root = CoroFromTexpr.optimize_cfg ctx cb_root in
+		let cb_root = if ctx.optimize then CoroFromTexpr.optimize_cfg ctx cb_root else cb_root in
 		coro_to_state_machine ctx coro_class cb_root exprs args vtmp vcompletion vcontinuation,cb_root
 	with CoroTco cb_root ->
 		coro_to_normal ctx coro_class cb_root exprs vcontinuation,cb_root
@@ -496,6 +496,7 @@ let create_coro_context typer meta =
 	let ctx = {
 		typer;
 		coro_debug = Meta.has (Meta.Custom ":coroutine.debug") meta;
+		optimize = not (Define.raw_defined typer.com.defines ":coroutine.noopt");
 		allow_tco = not (Meta.has (Meta.Custom ":coroutine.notco") meta);
 		throw = Define.raw_defined typer.com.defines "coroutine.throw";
 		nothrow = Meta.has (Meta.Custom ":coroutine.nothrow") meta;

--- a/src/coro/coroDebug.ml
+++ b/src/coro/coroDebug.ml
@@ -15,6 +15,7 @@ let create_dotgraph path cb =
 			block cb_target;
 			DynArray.add edges (cb.cb_id,cb_target.cb_id,label,true);
 		in
+		let maybe_edge_block label = Option.may (edge_block label) in
 		let s = String.concat "\n" (DynArray.to_list (DynArray.map se cb.cb_el)) in
 		let flags = if has_block_flag cb CbResumeState then " resume" else if has_block_flag cb CbSuspendState then " suspend" else "" in
 		let s = if s = "" then Printf.sprintf "(%i%s)" cb.cb_id flags else Printf.sprintf "(%i%s)\n%s" cb.cb_id flags s in
@@ -22,7 +23,7 @@ let create_dotgraph path cb =
 			| NextUnknown ->
 				None
 			| NextSub(cb_sub,cb_next) ->
-				edge_block "next" cb_next;
+				maybe_edge_block "next" cb_next;
 				edge_block "sub" cb_sub;
 				None
 			| NextBreak cb_break ->
@@ -42,23 +43,23 @@ let create_dotgraph path cb =
 				edge_block "then" cb_then;
 				Some ("if " ^ se e)
 			| NextIfThenElse(e,cb_then,cb_else,cb_next) ->
-				edge_block "next" cb_next;
+				maybe_edge_block "next" cb_next;
 				edge_block "then" cb_then;
 				edge_block "else" cb_else;
 				Some ("if " ^ se e)
 			| NextSwitch(switch,cb_next) ->
-				edge_block "next" cb_next;
+				maybe_edge_block "next" cb_next;
 				List.iter (fun (el,cb_case) ->
 					edge_block (String.concat " | " (List.map se el)) cb_case
 				) switch.cs_cases;
 				Option.may (fun cb_default -> edge_block "default" cb_default) switch.cs_default;
 				Some ("switch " ^ se switch.cs_subject)
 			| NextWhile(e,cb_body,cb_next) ->
-				edge_block "next" cb_next;
+				maybe_edge_block "next" cb_next;
 				edge_block "body" cb_body;
 				Some ("while " ^ se e)
 			| NextTry(cb_try,catch,cb_next) ->
-				edge_block "next" cb_next;
+				maybe_edge_block "next" cb_next;
 				edge_block "try" cb_try;
 				DynArray.add edges (cb_try.cb_id,catch.cc_cb.cb_id,"catch",true);
 				Printf.fprintf ch "n%i [shape=box,label=\"(%i)\"];\n" catch.cc_cb.cb_id catch.cc_cb.cb_id;
@@ -68,7 +69,7 @@ let create_dotgraph path cb =
 				) catch.cc_catches;
 				None
 			| NextSuspend(suspend,cb_next) ->
-				edge_block "next" cb_next;
+				maybe_edge_block "next" cb_next;
 				Some (Printf.sprintf "%s(%s)" (se suspend.cs_fun) (String.concat ", " (List.map se suspend.cs_args)))
 			| NextFallThrough cb_next ->
 				DynArray.add edges (cb.cb_id,cb_next.cb_id,"fall-through",false);

--- a/src/coro/coroFromTexpr.ml
+++ b/src/coro/coroFromTexpr.ml
@@ -35,11 +35,11 @@ let expr_to_coro ctx etmp cb_root e =
 			OptimizerTexpr.has_side_effect e
 	in
 	let add_expr cb e =
-		if cb.cb_next = NextUnknown && e != e_no_value && cb != ctx.cb_unreachable && has_side_effect e then
+		if cb.cb_next = NextUnknown && e != e_no_value && has_side_effect e then
 			DynArray.add cb.cb_el e
 	in
 	let terminate cb kind t p =
-		if cb.cb_next = NextUnknown && cb != ctx.cb_unreachable then
+		if cb.cb_next = NextUnknown then
 			cb.cb_next <- kind;
 	in
 	let fall_through cb_from cb_to =
@@ -52,206 +52,243 @@ let expr_to_coro ctx etmp cb_root e =
 	let rec loop cb ret e = match e.eexpr with
 		(* special cases *)
 		| TConst TThis ->
-			cb,e
+			Some (cb,e)
 		(* simple values *)
 		| TConst _ | TLocal _ | TTypeExpr _ | TIdent _ ->
-			cb,e
+			Some (cb,e)
 		(* compound values *)
 		| TBlock [e1] ->
 			loop cb ret e1
 		| TBlock _ ->
 			let cb_sub = block_from_e e in
-			let cb_sub_next,e1 = loop_block cb_sub ret e in
-			let cb_next = if cb_sub_next == ctx.cb_unreachable then
-				cb_sub_next
-			else begin
-				let cb_next = make_block None in
-				fall_through cb_sub_next cb_next;
-				cb_next
-			end in
-			terminate cb (NextSub(cb_sub,cb_next)) e.etype e.epos;
-			cb_next,e1
+			let sub_next = loop_block cb_sub ret e in
+			let cb_next = match sub_next with
+				| None ->
+					None
+				| Some (cb_sub_next,e1) ->
+					let cb_next = make_block None in
+					fall_through cb_sub_next cb_next;
+					Some (cb_next,e1)
+			in
+			terminate cb (NextSub(cb_sub,Option.map fst cb_next)) e.etype e.epos;
+			cb_next
 		| TArray(e1,e2) ->
-			let cb,el = ordered_loop cb [e1;e2] in
-			begin match el with
-			| [e1;e2] ->
-				cb,{e with eexpr = TArray(e1,e2)}
-			| _ ->
-				die "" __LOC__
-			end
+			let cb = ordered_loop cb [e1;e2] in
+			Option.map (fun (cb,el) -> match el with
+				| [e1;e2] ->
+					(cb,{e with eexpr = TArray(e1,e2)})
+				| _ ->
+					die "" __LOC__
+			) cb
 		| TArrayDecl el ->
-			let cb,el = ordered_loop cb el in
-			cb,{e with eexpr = TArrayDecl el}
+			let cb = ordered_loop cb el in
+			Option.map (fun (cb,el) -> (cb,{e with eexpr = TArrayDecl el})) cb
 		| TObjectDecl fl ->
-			let cb,el = ordered_loop cb (List.map snd fl) in
-			let fl = List.map2 (fun (f,_) e -> (f,e)) fl el in
-			cb,{e with eexpr = TObjectDecl fl}
+			let cb = ordered_loop cb (List.map snd fl) in
+			Option.map (fun (cb,el) ->
+				let fl = List.map2 (fun (f,_) e -> (f,e)) fl el in
+				(cb,{e with eexpr = TObjectDecl fl})
+			) cb
 		| TField(e1,fa) ->
 			(* TODO: this is quite annoying because factoring out field access behaves very creatively on
 			   some targets. This means that (coroCall()).field doesn't work (and isn't tested). *)
-			cb,e
+			Some (cb,e)
 		| TEnumParameter(e1,ef,i) ->
-			let cb,e1 = loop cb RValue e1 in
-			cb,{e with eexpr = TEnumParameter(e1,ef,i)}
+			let cb = loop cb RValue e1 in
+			Option.map (fun (cb,e) -> (cb,{e with eexpr = TEnumParameter(e1,ef,i)})) cb
 		| TEnumIndex e1 ->
-			let cb,e1 = loop cb RValue e1 in
-			cb,{e with eexpr = TEnumIndex e1}
+			let cb = loop cb RValue e1 in
+			Option.map (fun (cb,e1) -> (cb,{e with eexpr = TEnumIndex e1})) cb
 		| TNew(c,tl,el) ->
-			let cb,el = ordered_loop cb el in
-			cb,{e with eexpr = TNew(c,tl,el)}
+			let cb = ordered_loop cb el in
+			Option.map (fun (cb,e1) -> cb,{e with eexpr = TNew(c,tl,el)}) cb
 		(* rewrites & forwards *)
 		| TCast(e1,o) ->
-			let cb,e1 = loop cb ret e1 in
-			if e1 == e_no_value then
-				cb,e1
-			else
-				cb,{e with eexpr = TCast(e1,o)}
+			let cb = loop cb ret e1 in
+			Option.map (fun (cb,e1) -> (cb,{e with eexpr = TCast(e1,o)})) cb
 		| TParenthesis e1 ->
-			let cb,e1 = loop cb ret e1 in
-			if e1 == e_no_value then
-				cb,e1
-			else
-				cb,{e with eexpr = TParenthesis e1}
+			let cb = loop cb ret e1 in
+			Option.map (fun (cb,e1) -> (cb,{e with eexpr = TParenthesis e1})) cb
 		| TMeta(meta,e1) ->
-			let cb,e1 = loop cb ret e1 in
-			if e1 == e_no_value then
-				cb,e1
-			else
-				cb,{e with eexpr = TMeta(meta,e1)}
+			let cb = loop cb ret e1 in
+			Option.map (fun (cb,e1) -> (cb,{e with eexpr = TMeta(meta,e1)})) cb
 		| TUnop(op,flag,e1) ->
-			let cb,e1 = loop cb ret (* TODO: is this right? *) e1 in
-			cb,{e with eexpr = TUnop(op,flag,e1)}
+			let cb = loop cb ret (* TODO: is this right? *) e1 in
+			Option.map (fun (cb,e1) -> (cb,{e with eexpr = TUnop(op,flag,e1)})) cb
 		| TBinop(OpAssign,({eexpr = TLocal v} as e1),e2) ->
-			let cb,e2 = loop_assign cb (RLocal v) e2 in
-			cb,{e with eexpr = TBinop(OpAssign,e1,e2)}
+			let cb = loop_assign cb (RLocal v) e2 in
+			Option.map (fun (cb,e2) -> (cb,{e with eexpr = TBinop(OpAssign,e1,e2)})) cb
 		(* TODO: OpAssignOp and other OpAssign *)
 		| TBinop(op,e1,e2) ->
-			let cb,e1 = loop cb RValue e1 in
-			let cb,e2 = loop cb RValue e2 in
-			cb,{e with eexpr = TBinop(op,e1,e2)}
+			let cb = loop cb RValue e1 in
+			begin match cb with
+			| None ->
+				None
+			| Some (cb,e1) ->
+				let cb2 = loop cb RValue e2 in
+				begin match cb2 with
+				| None ->
+					add_expr cb e1;
+					None
+				| Some (cb,e2) ->
+					Some (cb,{e with eexpr = TBinop(op,e1,e2)})
+				end
+			end
 		(* variables *)
 		| TVar(v,None) ->
 			add_expr cb e;
-			cb,e_no_value
+			Some (cb,e_no_value)
 		| TVar(v,Some e1) ->
 			add_expr cb {e with eexpr = TVar(v,None)};
-			let cb,e1 = loop_assign cb (RLocal v) e1 in
-			cb,e1
+			let cb = loop_assign cb (RLocal v) e1 in
+			cb
 		(* calls *)
 		| TCall(e1,el) ->
-			let cb,el = ordered_loop cb (e1 :: el) in
-			begin match el with
-				| e1 :: el ->
-					begin match follow_with_coro e1.etype with
-					| Coro _ ->
-						let cb_next = block_from_e e1 in
-						add_block_flag cb_next CbResumeState;
-						let suspend = {
-							cs_fun = e1;
-							cs_args = el;
-							cs_pos = e.epos
-						} in
-						add_block_flag cb CbSuspendState;
-						terminate cb (NextSuspend(suspend,cb_next)) t_dynamic null_pos;
-						cb_next,etmp
-					| _ ->
-						cb,{e with eexpr = TCall(e1,el)}
-					end
-				| [] ->
-					die "" __LOC__
-			end
+			let cb = ordered_loop cb (e1 :: el) in
+			Option.map (fun (cb,el) ->
+				begin match el with
+					| e1 :: el ->
+						begin match follow_with_coro e1.etype with
+						| Coro _ ->
+							let cb_next = block_from_e e1 in
+							add_block_flag cb_next CbResumeState;
+							let suspend = {
+								cs_fun = e1;
+								cs_args = el;
+								cs_pos = e.epos
+							} in
+							add_block_flag cb CbSuspendState;
+							terminate cb (NextSuspend(suspend,Some cb_next)) t_dynamic null_pos;
+							cb_next,etmp
+						| _ ->
+							cb,{e with eexpr = TCall(e1,el)}
+						end
+					| [] ->
+						die "" __LOC__
+				end
+			) cb
 		(* terminators *)
 		| TBreak ->
-			terminate cb (NextBreak (snd (List.hd !loop_stack))) e.etype e.epos;
-			cb,e_no_value
+			terminate cb (NextBreak (Lazy.force (snd (List.hd !loop_stack)))) e.etype e.epos;
+			None
 		| TContinue ->
 			terminate cb (NextContinue (fst (List.hd !loop_stack))) e.etype e.epos;
-			cb,e_no_value
+			None
 		| TReturn None ->
 			terminate cb NextReturnVoid e.etype e.epos;
-			ctx.cb_unreachable,e_no_value
+			None
 		| TReturn (Some e1) ->
 			let f_terminate cb e1 =
 				terminate cb (NextReturn e1) e.etype e.epos;
 			in
 			let ret = RTerminate f_terminate in
-			let cb_ret,e1 = loop_assign cb ret e1 in
-			terminate cb_ret (NextReturn e1) e.etype e.epos;
-			ctx.cb_unreachable,e_no_value
+			let cb_ret = loop_assign cb ret e1 in
+			Option.may (fun (cb_ret,e1) -> terminate cb_ret (NextReturn e1) e.etype e.epos) cb_ret;
+			None
 		| TThrow e1 ->
 			let f_terminate cb e1 =
 				terminate cb (NextThrow e1) e.etype e.epos;
 			in
 			let ret = RTerminate f_terminate in
-			let cb_ret,e1 = loop_assign cb ret e1 in
-			terminate cb_ret (NextThrow e1) e.etype e.epos;
-			ctx.cb_unreachable,e_no_value
+			let cb_ret = loop_assign cb ret e1 in
+			Option.may (fun (cb_ret,e1) -> terminate cb_ret (NextThrow e1) e.etype e.epos) cb_ret;
+			None
 		(* branching *)
 		| TIf(e1,e2,None) ->
-			let cb,e1 = loop cb RValue e1 in
-			let cb_then = block_from_e e2 in
-			let cb_then_next,_ = loop_block cb_then RBlock e2 in
-			let cb_next = make_block None in
-			fall_through cb_then_next cb_next;
-			terminate cb (NextIfThen(e1,cb_then,cb_next)) e.etype e.epos;
-			cb_next,e_no_value
+			let cb = loop cb RValue e1 in
+			Option.map (fun (cb,e1) ->
+				let cb_then = block_from_e e2 in
+				let cb_then_next = loop_block cb_then RBlock e2 in
+				let cb_next = make_block None in
+				Option.may (fun (cb_then_next,_) -> fall_through cb_then_next cb_next) cb_then_next;
+				terminate cb (NextIfThen(e1,cb_then,cb_next)) e.etype e.epos;
+				cb_next,e_no_value
+			) cb
 		| TIf(e1,e2,Some e3) ->
-			let cb,e1 = loop cb RValue e1 in
-			let cb_then = block_from_e e2 in
-			let cb_then_next,_ = loop_block cb_then ret e2 in
-			let cb_else = block_from_e e3 in
-			let cb_else_next,_ = loop_block cb_else ret e3 in
-			let cb_next = make_block None in
-			fall_through cb_then_next cb_next;
-			fall_through cb_else_next cb_next;
-			terminate cb (NextIfThenElse(e1,cb_then,cb_else,cb_next)) e.etype e.epos;
-			cb_next,e_no_value
-		| TSwitch switch ->
-			let e1 = switch.switch_subject in
-			let cb,e1 = loop cb RValue e1 in
-			let cb_next = make_block None in
-			let cases = List.map (fun case ->
-				let cb_case = block_from_e case.case_expr in
-				let cb_case_next,_ = loop_block cb_case ret case.case_expr in
-				fall_through cb_case_next cb_next;
-				(case.case_patterns,cb_case)
-			) switch.switch_cases in
-			let def = match switch.switch_default with
+			let cb = loop cb RValue e1 in
+			begin match cb with
 				| None ->
 					None
-				| Some e ->
-					let cb_default = block_from_e e in
-					let cb_default_next,_ = loop_block cb_default ret e in
-					fall_through cb_default_next cb_next;
-					Some cb_default
-			in
-			let switch = {
-				cs_subject = e1;
-				cs_cases = cases;
-				cs_default = def;
-				cs_exhaustive = switch.switch_exhaustive
-			} in
-			terminate cb (NextSwitch(switch,cb_next)) e.etype e.epos;
-			cb_next,e_no_value
+				| Some(cb,e1) ->
+					let cb_then = block_from_e e2 in
+					let cb_then_next = loop_block cb_then ret e2 in
+					let cb_else = block_from_e e3 in
+					let cb_else_next = loop_block cb_else ret e3 in
+					let cb_next = match cb_then_next,cb_else_next with
+						| Some (cb_then_next,_),Some(cb_else_next,_) ->
+							let cb_next = make_block None in
+							fall_through cb_then_next cb_next;
+							fall_through cb_else_next cb_next;
+							Some cb_next
+						| (Some (cb_branch_next,_),None) | (None,Some (cb_branch_next,_)) ->
+							let cb_next = make_block None in
+							fall_through cb_branch_next cb_next;
+							Some cb_next
+						| None,None ->
+							None
+					in
+					terminate cb (NextIfThenElse(e1,cb_then,cb_else,cb_next)) e.etype e.epos;
+					Option.map (fun cb_next -> (cb_next,e_no_value)) cb_next
+			end
+		| TSwitch switch ->
+			let e1 = switch.switch_subject in
+			let cb = loop cb RValue e1 in
+			begin match cb with
+				| None ->
+					None
+				| Some(cb,e1) ->
+					let cb_next = lazy (make_block None) in
+					let cases = List.map (fun case ->
+						let cb_case = block_from_e case.case_expr in
+						let cb_case_next = loop_block cb_case ret case.case_expr in
+						Option.may (fun (cb_case_next,_) ->
+							fall_through cb_case_next (Lazy.force cb_next);
+						) cb_case_next;
+						(case.case_patterns,cb_case)
+					) switch.switch_cases in
+					let def = match switch.switch_default with
+						| None ->
+							None
+						| Some e ->
+							let cb_default = block_from_e e in
+							let cb_default_next = loop_block cb_default ret e in
+							Option.may (fun (cb_default_next,_) ->
+								fall_through cb_default_next (Lazy.force cb_next);
+							) cb_default_next;
+							Some cb_default
+					in
+					let switch = {
+						cs_subject = e1;
+						cs_cases = cases;
+						cs_default = def;
+						cs_exhaustive = switch.switch_exhaustive
+					} in
+					let cb_next = if Lazy.is_val cb_next || not switch.cs_exhaustive then Some (Lazy.force cb_next) else None in
+					terminate cb (NextSwitch(switch,cb_next)) e.etype e.epos;
+					Option.map (fun cb_next -> (cb_next,e_no_value)) cb_next
+			end
 		| TWhile(e1,e2,flag) when not (is_true_expr e1) ->
 			loop cb ret (Texpr.not_while_true_to_while_true ctx.typer.com.Common.basic e1 e2 flag e.etype e.epos)
 		| TWhile(e1,e2,flag) (* always while(true) *) ->
-			let cb_next = make_block None in
+			let cb_next = lazy (make_block None) in
 			let cb_body = block_from_e e2 in
 			loop_stack := (cb_body,cb_next) :: !loop_stack;
-			let cb_body_next,_ = loop_block cb_body RBlock e2 in
-			goto cb_body_next cb_body;
+			let cb_body_next = loop_block cb_body RBlock e2 in
+			Option.may (fun (cb_body_next,_) -> goto cb_body_next cb_body) cb_body_next;
 			loop_stack := List.tl !loop_stack;
+			let cb_next = if Lazy.is_val cb_next then Some (Lazy.force cb_next) else None in
 			terminate cb (NextWhile(e1,cb_body,cb_next)) e.etype e.epos;
-			cb_next,e_no_value
+			Option.map (fun cb_next -> (cb_next,e_no_value)) cb_next
 		| TTry(e1,catches) ->
 			ctx.has_catch <- true;
-			let cb_next = make_block None in
+			let cb_next = lazy (make_block None) in
 			let catches = List.map (fun (v,e) ->
 				let cb_catch = block_from_e e in
 				add_expr cb_catch (mk (TVar(v,Some etmp)) ctx.typer.t.tvoid null_pos);
-				let cb_catch_next,_ = loop_block cb_catch ret e in
-				fall_through cb_catch_next cb_next;
+				let cb_catch_next = loop_block cb_catch ret e in
+				Option.may (fun (cb_catch_next,_) ->
+					fall_through cb_catch_next (Lazy.force cb_next);
+				) cb_catch_next;
 				v,cb_catch
 			) catches in
 			let catch = make_block None in
@@ -265,43 +302,58 @@ let expr_to_coro ctx etmp cb_root e =
 				cc_catches = catches;
 			} in
 			let cb_try = block_from_e e1 in
-			let cb_try_next,_ = loop_block cb_try ret e1 in
+			let cb_try_next = loop_block cb_try ret e1 in
 			ctx.current_catch <- old;
-			fall_through cb_try_next cb_next;
+			Option.may (fun (cb_try_next,_) ->
+				fall_through cb_try_next (Lazy.force cb_next)
+			) cb_try_next;
+			let cb_next = if Lazy.is_val cb_next then Some (Lazy.force cb_next) else None in
 			terminate cb (NextTry(cb_try,catch,cb_next)) e.etype e.epos;
-			cb_next,e_no_value
+			Option.map (fun cb_next -> (cb_next,e_no_value)) cb_next
 		| TFunction tf ->
-			cb,e
+			Some (cb,e)
 	and ordered_loop cb el =
 		let close = start_ordered_value_list () in
 		let rec aux' cb acc el = match el with
 			| [] ->
-				cb,List.rev acc
+				Some (cb,List.rev acc)
 			| e :: el ->
-				let cb,e = loop cb RValue e in
-				aux' cb (e :: acc) el
+				let cb' = loop cb RValue e in
+				match cb' with
+				| None ->
+					List.iter (fun e ->
+						add_expr cb e
+					) (List.rev acc);
+					None
+				| Some (cb,e) ->
+					aux' cb (e :: acc) el
 		in
-		let cb,el = aux' cb [] el in
+		let cb = aux' cb [] el in
 		let _ = close () in
-		cb,el
+		cb
 	and loop_assign cb ret e =
-		let cb,e = loop cb ret e in
-		if e == e_no_value then
-			cb,e
-		else match ret with
+		let cb = loop cb ret e in
+		match cb with
+		| Some (cb,e) when e != e_no_value ->
+			begin match ret with
 			| RBlock ->
 				add_expr cb e;
-				cb,e_no_value
+				Some (cb,e_no_value)
 			| RValue ->
-				cb,e
+				Some (cb,e)
 			| RLocal v ->
 				let ev = Texpr.Builder.make_local v v.v_pos in
 				let eass = Texpr.Builder.binop OpAssign ev e ev.etype ev.epos in
 				add_expr cb eass;
-				cb,ev
+				Some (cb,ev)
 			| RTerminate f ->
 				f cb e;
-				ctx.cb_unreachable,e_no_value
+				None
+			end
+		| Some(cb,e) ->
+			Some(cb,e)
+		| None ->
+			None
 	and loop_block cb ret e =
 		let el = match e.eexpr with
 			| TBlock el ->
@@ -315,13 +367,18 @@ let expr_to_coro ctx etmp cb_root e =
 			| [e] ->
 				loop_assign cb ret e
 			| e :: el ->
-				let cb,e = loop cb RBlock e in
-				add_expr cb e;
-				aux' cb el
+				let cb = loop cb RBlock e in
+				begin match cb with
+				| None ->
+					None
+				| Some(cb,e) ->
+					add_expr cb e;
+					aux' cb el
+				end
 		in
 		match el with
 			| [] ->
-				cb,e_no_value
+				None
 			| _ ->
 				aux' cb el
 	in
@@ -344,7 +401,7 @@ let optimize_cfg ctx cb =
 		if not (has_block_flag cb CbEmptyMarked) then begin
 			add_block_flag cb CbEmptyMarked;
 			match cb.cb_next with
-			| NextSub(cb_sub,cb_next) when cb_next == ctx.cb_unreachable ->
+			| NextSub(cb_sub,None) ->
 				loop cb_sub;
 				forward_el cb cb_sub;
 				if has_block_flag cb CbResumeState then add_block_flag cb_sub CbResumeState;
@@ -370,12 +427,15 @@ let optimize_cfg ctx cb =
 			cb
 	in
 	let cb = loop cb in
-	let is_empty_termination_block cb =
-		DynArray.empty cb.cb_el && match cb.cb_next with
-			| NextReturnVoid | NextUnknown ->
-				true
-			| _ ->
-				false
+	let is_empty_termination_block cb = match cb with
+		| None ->
+			true
+		| Some cb ->
+			DynArray.empty cb.cb_el && match cb.cb_next with
+				| NextReturnVoid | NextUnknown ->
+					true
+				| _ ->
+					false
 	in
 	let rec loop cb =
 		if not (has_block_flag cb CbTcoChecked) then begin

--- a/src/coro/coroFunctions.ml
+++ b/src/coro/coroFunctions.ml
@@ -36,32 +36,33 @@ let get_block_exprs cb =
 	loop (DynArray.length cb.cb_el - 1) []
 
 let coro_iter f cb =
-	Option.may f cb.cb_catch;
+	let fo = Option.may f in
+	fo cb.cb_catch;
 	match cb.cb_next with
 	| NextSub(cb_sub,cb_next) ->
 		f cb_sub;
-		f cb_next
+		fo cb_next
 	| NextIfThen(_,cb_then,cb_next) ->
 		f cb_then;
 		f cb_next;
 	| NextIfThenElse(_,cb_then,cb_else,cb_next) ->
 		f cb_then;
 		f cb_else;
-		f cb_next;
+		fo cb_next;
 	| NextSwitch(switch,cb_next) ->
 		List.iter (fun (_,cb) -> f cb) switch.cs_cases;
 		Option.may f switch.cs_default;
-		f cb_next;
+		fo cb_next;
 	| NextWhile(e,cb_body,cb_next) ->
 		f cb_body;
-		f cb_next;
+		fo cb_next;
 	| NextTry(cb_try,catch,cb_next) ->
 		f cb_try;
 		f catch.cc_cb;
 		List.iter (fun (_,cb) -> f cb) catch.cc_catches;
-		f cb_next;
+		fo cb_next;
 	| NextSuspend(call,cb_next) ->
-		f cb_next
+		fo cb_next
 	| NextBreak cb_next | NextContinue cb_next | NextFallThrough cb_next | NextGoto cb_next ->
 		f cb_next;
 	| NextUnknown | NextReturnVoid | NextReturn _ | NextThrow _ ->
@@ -69,10 +70,11 @@ let coro_iter f cb =
 
 let coro_next_map f cb =
 	Option.may (fun cb_catch -> cb.cb_catch <- Some (f cb_catch)) cb.cb_catch;
+	let fo = Option.map f in
 	match cb.cb_next with
 	| NextSub(cb_sub,cb_next) ->
 		let cb_sub = f cb_sub in
-		let cb_next = f cb_next in
+		let cb_next = fo cb_next in
 		cb.cb_next <- NextSub(cb_sub,cb_next);
 	| NextIfThen(e,cb_then,cb_next) ->
 		let cb_then = f cb_then in
@@ -81,7 +83,7 @@ let coro_next_map f cb =
 	| NextIfThenElse(e,cb_then,cb_else,cb_next) ->
 		let cb_then = f cb_then in
 		let cb_else = f cb_else in
-		let cb_next = f cb_next in
+		let cb_next = fo cb_next in
 		cb.cb_next <- NextIfThenElse(e,cb_then,cb_else,cb_next);
 	| NextSwitch(switch,cb_next) ->
 		let cases = List.map (fun (el,cb) -> (el,f cb)) switch.cs_cases in
@@ -89,11 +91,11 @@ let coro_next_map f cb =
 		let switch = {
 			switch with cs_cases = cases; cs_default = def
 		} in
-		let cb_next = f cb_next in
+		let cb_next = fo cb_next in
 		cb.cb_next <- NextSwitch(switch,cb_next);
 	| NextWhile(e,cb_body,cb_next) ->
 		let cb_body = f cb_body in
-		let cb_next = f cb_next in
+		let cb_next = fo cb_next in
 		cb.cb_next <- NextWhile(e,cb_body,cb_next);
 	| NextTry(cb_try,catch,cb_next) ->
 		let cb_try = f cb_try in
@@ -103,10 +105,10 @@ let coro_next_map f cb =
 			cc_cb;
 			cc_catches = catches
 		} in
-		let cb_next = f cb_next in
+		let cb_next = fo cb_next in
 		cb.cb_next <- NextTry(cb_try,catch,cb_next);
 	| NextSuspend(call,cb_next) ->
-		let cb_next = f cb_next in
+		let cb_next = fo cb_next in
 		cb.cb_next <- NextSuspend(call,cb_next);
 	| NextBreak cb_next ->
 		cb.cb_next <- NextBreak (f cb_next);

--- a/src/coro/coroToTexpr.ml
+++ b/src/coro/coroToTexpr.ml
@@ -272,7 +272,6 @@ let block_to_texpr_coroutine ctx cb cont cls tf_args forbidden_vars exprs p =
 
 	let exc_state_map = Array.init ctx.next_block_id (fun _ -> ref []) in
 	let generate cb =
-		assert (cb != ctx.cb_unreachable);
 		let el = get_block_exprs cb in
 
 		let add_state next_id extra_el =
@@ -302,7 +301,7 @@ let block_to_texpr_coroutine ctx cb cont cls tf_args forbidden_vars exprs p =
 		match cb.cb_next with
 		| NextSuspend (call, cb_next) ->
 			let ecallcoroutine = mk_suspending_call call in
-			add_state (Some cb_next.cb_id) ecallcoroutine;
+			add_state (Option.map (fun cb_next -> cb_next.cb_id) cb_next) ecallcoroutine;
 		| NextUnknown ->
 			add_state (Some (-1)) [set_control CoroReturned; ereturn]
 		| NextFallThrough cb_next | NextGoto cb_next | NextBreak cb_next | NextContinue cb_next ->
@@ -317,7 +316,6 @@ let block_to_texpr_coroutine ctx cb cont cls tf_args forbidden_vars exprs p =
 			else
 				add_state None [ b#assign etmp e1; b#break p ]
 		| NextSub (cb_sub,cb_next) ->
-			ignore(cb_next.cb_id);
 			add_state (Some cb_sub.cb_id) []
 
 		| NextIfThen (econd,cb_then,cb_next) ->
@@ -333,13 +331,13 @@ let block_to_texpr_coroutine ctx cb cont cls tf_args forbidden_vars exprs p =
 			let ecases = List.map (fun (patterns,cb) ->
 				{case_patterns = patterns;case_expr = set_state cb.cb_id}
 			) switch.cs_cases in
-			let default_state_id = match switch.cs_default with
+			let next_id = match switch.cs_default with
 				| Some cb ->
-					cb.cb_id
+					Some (set_state cb.cb_id)
 				| None ->
-					cb_next.cb_id
+					Option.map (fun cb_next -> set_state cb_next.cb_id) cb_next
 			in
-			let eswitch = mk_switch esubj ecases (Some (set_state default_state_id)) true in
+			let eswitch = mk_switch esubj ecases next_id true in
 			let eswitch = mk (TSwitch eswitch) com.basic.tvoid p in
 
 			add_state None [eswitch]

--- a/src/coro/coroTypes.ml
+++ b/src/coro/coroTypes.ml
@@ -10,18 +10,20 @@ type coro_block = {
 	mutable cb_flags : int;
 }
 
+and coro_block_next = coro_block option
+
 and coro_next =
 	| NextUnknown
-	| NextSub of coro_block * coro_block
+	| NextSub of coro_block * coro_block_next
 	| NextReturnVoid
 	| NextReturn of texpr
 	| NextThrow of texpr
 	| NextIfThen of texpr * coro_block * coro_block
-	| NextIfThenElse of texpr * coro_block * coro_block * coro_block
-	| NextSwitch of coro_switch * coro_block
-	| NextWhile of texpr * coro_block * coro_block
-	| NextTry of coro_block * coro_catch * coro_block
-	| NextSuspend of coro_suspend * coro_block
+	| NextIfThenElse of texpr * coro_block * coro_block * coro_block_next
+	| NextSwitch of coro_switch * coro_block_next
+	| NextWhile of texpr * coro_block * coro_block_next
+	| NextTry of coro_block * coro_catch * coro_block_next
+	| NextSuspend of coro_suspend * coro_block_next
 	(* graph connections from here on, careful with traversal *)
 	| NextBreak of coro_block
 	| NextContinue of coro_block
@@ -54,7 +56,6 @@ type coro_ctx = {
 	nothrow : bool;
 	mutable vthis : tvar option;
 	mutable next_block_id : int;
-	mutable cb_unreachable : coro_block;
 	mutable current_catch : coro_block option;
 	mutable has_catch : bool;
 }

--- a/src/coro/coroTypes.ml
+++ b/src/coro/coroTypes.ml
@@ -51,6 +51,7 @@ and coro_suspend = {
 type coro_ctx = {
 	typer : Typecore.typer;
 	coro_debug : bool;
+	optimize : bool;
 	allow_tco : bool;
 	throw : bool;
 	nothrow : bool;

--- a/tests/misc/coroutines/build-jvm.hxml
+++ b/tests/misc/coroutines/build-jvm.hxml
@@ -1,5 +1,3 @@
 build-base.hxml
---each
 --jvm bin/coro.jar
---hxb bin/coro.hxb
 --cmd java -jar bin/coro.jar

--- a/tests/misc/coroutines/src/issues/aidan/Issue59.hx
+++ b/tests/misc/coroutines/src/issues/aidan/Issue59.hx
@@ -8,7 +8,7 @@ function throwing() {
 	throw new NotImplementedException();
 }
 
-@:coroutine @:coroutine.debug function recursion(i:Int, acc:Int) {
+@:coroutine function recursion(i:Int, acc:Int) {
 	yield();
 	return if (i > 0) {
 		recursion(i - 1, acc + i);

--- a/tests/runci/targets/Cpp.hx
+++ b/tests/runci/targets/Cpp.hx
@@ -72,11 +72,9 @@ class Cpp {
 				runCpp("bin/cppia/Host-debug", ["bin/unit.cppia", "-jit"]);
 		}
 
-		changeDirectory(getMiscSubDir("coroutines"));
-		runCommand("haxe", ["build-cpp.hxml"]);
-		runCpp("bin/cpp/Main-debug");
-		runCommand("haxe", ["build-cpp.hxml", "-D", "coroutine.throw"]);
-		runCpp("bin/cpp/Main-debug");
+		runci.tests.CoroutineTests.run(["build-cpp.hxml"], args ->
+			runCpp("bin/cpp/Main-debug")
+		);
 
 		Display.maybeRunDisplayTests(Cpp);
 

--- a/tests/runci/targets/Hl.hx
+++ b/tests/runci/targets/Hl.hx
@@ -139,10 +139,7 @@ class Hl {
 		runCommand("haxe", ["compile-hlc.hxml", "--undefine", "analyzer-optimize"].concat(args));
 		buildAndRunHlc("bin/hlc", "unit", runCommand);
 
-		infoMsg("Test coroutines:");
-		changeDirectory(getMiscSubDir("coroutines"));
-		runCommand("haxe", ["build-hl.hxml"]);
-		runCommand("haxe", ["build-hl.hxml", "-D", "coroutine.throw"]);
+		runci.tests.CoroutineTests.run(["build-hl.hxml"]);
 
 		changeDirectory(threadsDir);
 		buildAndRun("build.hxml", "export/threads");

--- a/tests/runci/targets/Js.hx
+++ b/tests/runci/targets/Js.hx
@@ -76,10 +76,7 @@ class Js {
 		changeDirectory(getMiscSubDir("es6"));
 		runCommand("haxe", ["run.hxml"]);
 
-		infoMsg("Test coroutines:");
-		changeDirectory(getMiscSubDir("coroutines"));
-		runCommand("haxe", ["build-js.hxml"]);
-		runCommand("haxe", ["build-js.hxml", "-D", "coroutine.throw"]);
+		runci.tests.CoroutineTests.run(["build-js.hxml"]);
 
 		haxelibInstallGit("HaxeFoundation", "hxnodejs");
 		final env = Sys.environment();

--- a/tests/runci/targets/Jvm.hx
+++ b/tests/runci/targets/Jvm.hx
@@ -33,12 +33,10 @@ class Jvm {
 			runCommand("java", ["-jar", "bin/unit.jar"]);
 		}
 
-		infoMsg("Test coroutines:");
-		changeDirectory(getMiscSubDir("coroutines"));
-		runCommand("haxe", ["build-jvm.hxml", "--hxb", "bin/coro.hxb"]);
-		runCommand("haxe", ["build-jvm.hxml", "--hxb-lib", "bin/coro.hxb"]);
-		runCommand("haxe", ["build-jvm.hxml", "--hxb", "bin/coro.hxb", "-D", "coroutine.throw"]);
-		runCommand("haxe", ["build-jvm.hxml", "--hxb-lib", "bin/coro.hxb", "-D", "coroutine.throw"]);
+		runci.tests.CoroutineTests.run(["build-jvm.hxml", "--hxb", "bin/coro.hxb"], args ->
+			runCommand("haxe", args.concat(["--hxb-lib", "bin/coro.hxb"]))
+		);
+
 		Display.maybeRunDisplayTests(Jvm);
 
 		changeDirectory(miscJavaDir);

--- a/tests/runci/targets/Lua.hx
+++ b/tests/runci/targets/Lua.hx
@@ -96,9 +96,7 @@ class Lua {
 			runCommand("haxe", ["compile-lua.hxml"].concat(args).concat(luaVer));
 			runCommand("lua", ["bin/unit.lua"]);
 
-			changeDirectory(getMiscSubDir('coroutines'));
-			runCommand("haxe", ["build-lua.hxml"]);
-			runCommand("haxe", ["build-lua.hxml", "-D", "coroutine.throw"]);
+			runci.tests.CoroutineTests.run(["build-lua.hxml"]);
 
 			Display.maybeRunDisplayTests(Lua);
 

--- a/tests/runci/targets/Macro.hx
+++ b/tests/runci/targets/Macro.hx
@@ -8,10 +8,7 @@ class Macro {
 		runCommand("haxe", ["compile-macro.hxml", "--hxb", "bin/hxb/eval.zip"].concat(args));
 		runCommand("haxe", ["compile-macro.hxml", "--hxb-lib", "bin/hxb/eval.zip"].concat(args));
 
-		infoMsg("Test coroutines:");
-		changeDirectory(getMiscSubDir("coroutines"));
-		runCommand("haxe", ["build-eval.hxml"]);
-		runCommand("haxe", ["build-eval.hxml", "-D", "coroutine.throw"]);
+		runci.tests.CoroutineTests.run(["build-eval.hxml"]);
 
 		changeDirectory(displayDir);
 		haxelibInstallGit("Simn", "haxeserver");

--- a/tests/runci/targets/Neko.hx
+++ b/tests/runci/targets/Neko.hx
@@ -8,9 +8,7 @@ class Neko {
 		runCommand("haxe", ["compile-neko.hxml", "-D", "dump", "-D", "dump_ignore_var_ids"].concat(args));
 		runCommand("neko", ["bin/unit.n"]);
 
-		changeDirectory(getMiscSubDir('coroutines'));
-		runCommand("haxe", ["build-neko.hxml"]);
-		runCommand("haxe", ["build-neko.hxml", "-D", "coroutine.throw"]);
+		runci.tests.CoroutineTests.run(["build-neko.hxml"]);
 
 		changeDirectory(getMiscSubDir('neko'));
 		runCommand("haxe", ["run.hxml"].concat(args));

--- a/tests/runci/targets/Php.hx
+++ b/tests/runci/targets/Php.hx
@@ -87,9 +87,7 @@ class Php {
 			runCommand("haxe", ["compile-php.hxml"].concat(prefix).concat(args));
 			runCommand("php", generateArgs(binDir + "/index.php"));
 
-			changeDirectory(getMiscSubDir('coroutines'));
-			runCommand("haxe", ["build-php.hxml"]);
-			runCommand("haxe", ["build-php.hxml", "-D", "coroutine.throw"]);
+			runci.tests.CoroutineTests.run(["build-php.hxml"]);
 
 			Display.maybeRunDisplayTests(Php);
 

--- a/tests/runci/targets/Python.hx
+++ b/tests/runci/targets/Python.hx
@@ -67,9 +67,7 @@ class Python {
 			runCommand(py, ["bin/unit34.py"]);
 		}
 
-		changeDirectory(getMiscSubDir('coroutines'));
-		runCommand("haxe", ["build-python.hxml"]);
-		runCommand("haxe", ["build-python.hxml", "-D", "coroutine.throw"]);
+		runci.tests.CoroutineTests.run(["build-python.hxml"]);
 
 		Display.maybeRunDisplayTests(Python);
 

--- a/tests/runci/tests/CoroutineTests.hx
+++ b/tests/runci/tests/CoroutineTests.hx
@@ -1,0 +1,21 @@
+package runci.tests;
+
+import runci.System.*;
+import runci.Config.*;
+
+class CoroutineTests {
+	static public function run(baseArgs:Array<String>, ?afterwards:(args:Array<String>) -> Void) {
+		infoMsg("Test coroutines:");
+		changeDirectory(getMiscSubDir("coroutines"));
+		for (opt in [[], ["-D", "coroutine.noopt"]]) {
+			for (thro in [[], ["-D", "coroutine.throw"]]) {
+				var args = baseArgs.concat(opt).concat(thro);
+				infoMsg("Running " + args.join(" "));
+				runCommand("haxe", args);
+				if (afterwards != null) {
+					afterwards(args);
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
I came across situations where we had the unreachable block in final graph and since I don't want to have this kind of cognitive burden, I went ahead and removed it. This makes everything in `coroFromTexpr` a little more awkward, but we're barely touching that code anymore anyway, so it's fine.

This also adds `-D coroutine.noopt` to disable the optimization stage, and test it across all targets.