### PR TITLE
Prefixes and collisions

### DIFF
--- a/src/coro/coro.ml
+++ b/src/coro/coro.ml
@@ -47,7 +47,7 @@ module ContinuationClassBuilder = struct
 		let basic = ctx.typer.t in
 		(* Mangle class names to hopefully get unique names and avoid collisions *)
 		let name, cf_captured, params_outside, result_type, name_pos =
-			let captured_field_name = "_hx_captured" in
+			let captured_field_name = "captured" in
 			match coro_type with
 			| ClassField (cls, field, tf, _) ->
 				Printf.sprintf "HxCoro_%s_%s_%s" (ctx.typer.m.curmod.m_path |> fst |> String.concat "_") (ctx.typer.m.curmod.m_path |> snd) field.cf_name,
@@ -90,13 +90,13 @@ module ContinuationClassBuilder = struct
 			| Some api ->
 				api
 			| None ->
-				let cf_control    = PMap.find "_hx_control" basic.tcoro.suspension_result_class.cl_fields in
-				let cf_result     = PMap.find "_hx_result" basic.tcoro.suspension_result_class.cl_fields in
-				let cf_error      = PMap.find "_hx_error" basic.tcoro.suspension_result_class.cl_fields in
-				let cf_completion = PMap.find "_hx_completion" basic.tcoro.base_continuation_class.cl_fields in
-				let cf_context    = PMap.find "_hx_context" basic.tcoro.base_continuation_class.cl_fields in
-				let cf_state      = PMap.find "_hx_state" basic.tcoro.base_continuation_class.cl_fields in
-				let cf_recursing  = PMap.find "_hx_recursing" basic.tcoro.base_continuation_class.cl_fields in
+				let cf_control    = PMap.find "control" basic.tcoro.suspension_result_class.cl_fields in
+				let cf_result     = PMap.find "result" basic.tcoro.suspension_result_class.cl_fields in
+				let cf_error      = PMap.find "error" basic.tcoro.suspension_result_class.cl_fields in
+				let cf_completion = PMap.find "completion" basic.tcoro.base_continuation_class.cl_fields in
+				let cf_context    = PMap.find "context" basic.tcoro.base_continuation_class.cl_fields in
+				let cf_state      = PMap.find "state" basic.tcoro.base_continuation_class.cl_fields in
+				let cf_recursing  = PMap.find "recursing" basic.tcoro.base_continuation_class.cl_fields in
 				let immediate_result,immediate_error =
 					let c = basic.tcoro.immediate_suspension_result_class in
 					let cf_result = PMap.find "withResult" c.cl_statics in

--- a/src/coro/coroToTexpr.ml
+++ b/src/coro/coroToTexpr.ml
@@ -92,7 +92,7 @@ let handle_locals ctx b cls states tf_args forbidden_vars econtinuation =
 		tf_args
 		|> List.filter_map (fun (v, _) ->
 			if is_used_across_states v.v_id then
-				Some (v.v_id, mk_field v.v_name v.v_type v.v_pos v.v_pos)
+				Some (v.v_id, mk_field (Printf.sprintf "_hx_hoisted%i" v.v_id) v.v_type v.v_pos v.v_pos)
 			else
 				None)
 		|> List.to_seq
@@ -103,11 +103,7 @@ let handle_locals ctx b cls states tf_args forbidden_vars econtinuation =
 		let rec loop e =
 			match e.eexpr with
 			| TVar (v, eo) when is_used_across_states v.v_id ->
-				let name = if v.v_kind = VGenerated then
-					Printf.sprintf "_hx_hoisted%i" v.v_id
-				else
-					v.v_name in
-
+				let name  = Printf.sprintf "_hx_hoisted%i" v.v_id in
 				let field = mk_field name v.v_type v.v_pos v.v_pos in
 
 				Hashtbl.replace fields v.v_id field;

--- a/std/haxe/coro/BaseContinuation.hx
+++ b/std/haxe/coro/BaseContinuation.hx
@@ -4,90 +4,91 @@ import haxe.CallStack.StackItem;
 import haxe.Exception;
 
 abstract class BaseContinuation<T> extends SuspensionResult<T> implements IContinuation<T> implements IStackFrame {
-    public final _hx_completion:IContinuation<Any>;
+    public final completion:IContinuation<Any>;
 
-	public final _hx_context:CoroutineContext;
+	public final context:CoroutineContext;
 
-    public var _hx_state:Int;
+    public var state:Int;
 
-    public var _hx_recursing:Bool;
+    public var recursing:Bool;
 
     function new(completion:IContinuation<Any>, initialState:Int) {
-        _hx_completion = completion;
-        _hx_context    = completion._hx_context;
-        _hx_state      = initialState;
-        _hx_error      = null;
-        _hx_result     = null;
-        _hx_recursing  = false;
+        this.completion = completion;
+
+        context    = completion.context;
+        state      = initialState;
+        error      = null;
+        result     = null;
+        recursing  = false;
     }
 
     public final function resume(result:Any, error:Exception):Void {
-        _hx_result = result;
-        _hx_error  = error;
-        _hx_context.scheduler.schedule(() -> {
-			_hx_recursing = false;
+        this.result = result;
+        this.error  = error;
+        context.scheduler.schedule(() -> {
+			recursing = false;
 
 			#if coroutine.throw
 			try {
 			#end
 			final result = invokeResume();
-			switch (result._hx_control) {
+			switch (result.control) {
 				case Pending:
 					return;
 				case Returned:
-					_hx_completion.resume(result._hx_result, null);
+					completion.resume(result.result, null);
 				case Thrown:
-					_hx_completion.resume(result._hx_result, result._hx_error);
+					completion.resume(result.result, result.error);
 			}
 			#if coroutine.throw
 			} catch (e:Dynamic) {
-				_hx_completion.resume(null, @:privateAccess Exception.thrown(e));
+				completion.resume(null, @:privateAccess Exception.thrown(e));
 			}
 			#end
         });
     }
 
     public function callerFrame():Null<IStackFrame> {
-        return if (_hx_completion is IStackFrame) {
-            cast _hx_completion;
+        return if (completion is IStackFrame) {
+            cast completion;
         } else {
             null;
         }
     }
 
 	public function getStackItem():Null<StackItem> {
-		return cast _hx_result;
+		return cast result;
 	}
 
     public function setClassFuncStackItem(cls:String, func:String, file:String, line:Int, pos:Int, pmin:Int, pmax:Int) {
-        _hx_result = cast StackItem.FilePos(StackItem.Method(cls, func), file, line, pos);
+        result = cast StackItem.FilePos(StackItem.Method(cls, func), file, line, pos);
     }
 
     public function setLocalFuncStackItem(id:Int, file:String, line:Int, pos:Int, pmin:Int, pmax:Int) {
-        _hx_result = cast StackItem.FilePos(StackItem.LocalFunction(id), file, line, pos);
+        result = cast StackItem.FilePos(StackItem.LocalFunction(id), file, line, pos);
     }
 
 	public function startException(fromThrow:Bool) {
 		if (fromThrow) {
 			/*
 				This comes from a coro-level throw, which pushes its position via one of the functions
-				above. In this case we turn _hx_result into the stack item array now.
+				above. In this case we turn result into the stack item array now.
 			*/
-			_hx_result = cast [_hx_result];
+			result = cast [result];
 		} else {
 			/*
 				This means we caught an exception, which must come from outside our current coro. We
-				don't need our current _hx_result value because if anything it points to the last
+				don't need our current result value because if anything it points to the last
 				suspension call.
 			*/
-			_hx_result = cast [];
+			result = cast [];
 		}
 	}
 
     public function buildCallStack() {
         var frame = callerFrame();
         if (frame != null) {
-            (cast _hx_result : Array<StackItem>).push(frame.getStackItem());
+            (cast result : Array<StackItem>).push(frame.getStackItem());
         }
     }
 

--- a/std/haxe/coro/Coroutine.hx
+++ b/std/haxe/coro/Coroutine.hx
@@ -22,23 +22,23 @@ private class CoroSuspend<T> extends haxe.coro.BaseContinuation<T> {
 @:coreType
 abstract Coroutine<T:haxe.Constraints.Function> {
 	@:coroutine @:coroutine.transformed
-	public static function suspend<T>(func:haxe.coro.IContinuation<T>->Void, _hx_completion:haxe.coro.IContinuation<T>):T {
-		var _hx_continuation = new CoroSuspend(_hx_completion);
-		var safe = new haxe.coro.continuations.RacingContinuation(_hx_completion, _hx_continuation);
+	public static function suspend<T>(func:haxe.coro.IContinuation<T>->Void, completion:haxe.coro.IContinuation<T>):T {
+		var continuation = new CoroSuspend(completion);
+		var safe = new haxe.coro.continuations.RacingContinuation(completion, continuation);
 		func(safe);
 		safe.resolve();
-		return cast _hx_continuation;
+		return cast continuation;
 	}
 
 	@:coroutine @:coroutine.nothrow public static function delay(ms:Int):Void {
 		Coroutine.suspend(cont -> {
-			cont._hx_context.scheduler.scheduleIn(() -> cont.resume(null, null), ms);
+			cont.context.scheduler.scheduleIn(() -> cont.resume(null, null), ms);
 		});
 	}
 
 	@:coroutine @:coroutine.nothrow public static function yield():Void {
 		Coroutine.suspend(cont -> {
-			cont._hx_context.scheduler.schedule(() -> cont.resume(null, null));
+			cont.context.scheduler.schedule(() -> cont.resume(null, null));
 		});
 	}
 
@@ -47,13 +47,13 @@ abstract Coroutine<T:haxe.Constraints.Function> {
 		final cont = new BlockingContinuation<T>(loop, new EventLoopScheduler(loop));
 		final result = f(cont);
 
-		return switch (result._hx_control) {
+		return switch (result.control) {
 			case Pending:
 				cont.wait();
 			case Returned:
-				result._hx_result;
+				result.result;
 			case Thrown:
-				throw result._hx_error;
+				throw result.error;
 		}
 	}
 }

--- a/std/haxe/coro/IContinuation.hx
+++ b/std/haxe/coro/IContinuation.hx
@@ -3,7 +3,7 @@ package haxe.coro;
 import haxe.Exception;
 
 interface IContinuation<T> {
-	final _hx_context:CoroutineContext;
+	final context:CoroutineContext;
 
 	function resume(result:T, error:Exception):Void;
 }

--- a/std/haxe/coro/ImmediateSuspensionResult.hx
+++ b/std/haxe/coro/ImmediateSuspensionResult.hx
@@ -4,9 +4,9 @@ import haxe.Exception;
 
 class ImmediateSuspensionResult<T> extends SuspensionResult<T> {
 	function new(result:T, error:Exception) {
-		_hx_result = result;
-		_hx_error = error;
-		_hx_control = error == null ? Returned : Thrown;
+		this.result  = result;
+		this.error   = error;
+		this.control = error == null ? Returned : Thrown;
 	}
 
 	static public function withResult<T>(result:T) {
@@ -18,6 +18,6 @@ class ImmediateSuspensionResult<T> extends SuspensionResult<T> {
 	}
 
 	public override function toString() {
-		return '[ImmediateSuspensionResult ${_hx_control.toString()}, $_hx_result]';
+		return '[ImmediateSuspensionResult ${control.toString()}, $result]';
 	}
 }

--- a/std/haxe/coro/SuspensionResult.hx
+++ b/std/haxe/coro/SuspensionResult.hx
@@ -3,11 +3,11 @@ package haxe.coro;
 import haxe.Exception;
 
 abstract class SuspensionResult<T> {
-	public var _hx_control:SuspensionState;
-	public var _hx_result:T;
-	public var _hx_error:Exception;
+	public var control:SuspensionState;
+	public var result:T;
+	public var error:Exception;
 
 	public function toString() {
-		return '[SuspensionResult ${_hx_control.toString()}, $_hx_result]';
+		return '[SuspensionResult ${control.toString()}, $result]';
 	}
 }

--- a/std/haxe/coro/continuations/BlockingContinuation.hx
+++ b/std/haxe/coro/continuations/BlockingContinuation.hx
@@ -1,7 +1,7 @@
 package haxe.coro.continuations;
 
 class BlockingContinuation<T> implements IContinuation<T> {
-	public final _hx_context:CoroutineContext;
+	public final context:CoroutineContext;
 
 	final loop:EventLoop;
 
@@ -12,7 +12,7 @@ class BlockingContinuation<T> implements IContinuation<T> {
 	public function new(loop, scheduler) {
 		this.loop = loop;
 
-		_hx_context = new CoroutineContext(scheduler);
+		context = new CoroutineContext(scheduler);
 		running = true;
 		error = null;
 	}

--- a/std/haxe/coro/continuations/RacingContinuation.hx
+++ b/std/haxe/coro/continuations/RacingContinuation.hx
@@ -36,18 +36,18 @@ private class Thread {
 
 	var assigned:Bool;
 
-	public final _hx_context:CoroutineContext;
+	public final context:CoroutineContext;
 
 	public function new(inputCont:IContinuation<T>, outputCont:SuspensionResult<T>) {
 		this.inputCont = inputCont;
 		this.outputCont = outputCont;
-		_hx_context = inputCont._hx_context;
+		context = inputCont.context;
 		assigned = false;
 		lock = new Mutex();
 	}
 
 	public function resume(result:T, error:Exception):Void {
-		_hx_context.scheduler.schedule(() -> {
+		context.scheduler.schedule(() -> {
 			lock.acquire();
 
 			if (assigned) {
@@ -55,8 +55,8 @@ private class Thread {
 				inputCont.resume(result, error);
 			} else {
 				assigned = true;
-				outputCont._hx_result = result;
-				outputCont._hx_error = error;
+				outputCont.result = result;
+				outputCont.error = error;
 
 				lock.release();
 			}
@@ -66,16 +66,16 @@ private class Thread {
 	public function resolve():Void {
 		lock.acquire();
 		if (assigned) {
-			if (outputCont._hx_error != null) {
-				outputCont._hx_control = Thrown;
+			if (outputCont.error != null) {
+				outputCont.control = Thrown;
 				lock.release();
 			} else {
-				outputCont._hx_control = Returned;
+				outputCont.control = Returned;
 				lock.release();
 			}
 		} else {
 			assigned = true;
-			outputCont._hx_control = Pending;
+			outputCont.control = Pending;
 			lock.release();
 		}
 	}

--- a/tests/misc/coroutines/src/issues/aidan/Issue61.hx
+++ b/tests/misc/coroutines/src/issues/aidan/Issue61.hx
@@ -1,0 +1,21 @@
+package issues.aidan;
+
+import utest.Assert;
+import haxe.coro.Coroutine;
+import haxe.coro.Coroutine.yield;
+
+class Issue61 extends utest.Test {
+	public function test() {
+		Coroutine.run(foo);
+	}
+
+    @:coroutine function foo() {
+        var a = 2;
+        yield();
+        Assert.equals(2, a);
+
+        var a = 1;
+        yield();
+        Assert.equals(1, a);
+    }
+}


### PR DESCRIPTION
Closes #61,

all hoisted variable are now mangled to include their variable id to work around variable shadowing. I've removed all the `_hx_` prefixes (I think) from our core classes / interfaces since there shouldn't be collision issues anymore.
I've kept the `_hx_` prefix on the continuation and completion objects in the functions though.