### PR TITLE
Extensible context

### DIFF
--- a/std/haxe/coro/BaseContinuation.hx
+++ b/std/haxe/coro/BaseContinuation.hx
@@ -1,12 +1,14 @@
 package haxe.coro;
 
+import haxe.coro.context.Context;
+import haxe.coro.schedulers.Scheduler;
 import haxe.CallStack.StackItem;
 import haxe.Exception;
 
 abstract class BaseContinuation<T> extends SuspensionResult<T> implements IContinuation<T> implements IStackFrame {
     public final completion:IContinuation<Any>;
 
-	public final context:CoroutineContext;
+	public final context:Context;
 
     public var gotoLabel:Int;
 
@@ -25,7 +27,7 @@ abstract class BaseContinuation<T> extends SuspensionResult<T> implements IConti
     public final function resume(result:Any, error:Exception):Void {
         this.result = result;
         this.error  = error;
-        context.scheduler.schedule(() -> {
+        context.get(Scheduler.key).schedule(() -> {
 			recursing = false;
 
 			#if coroutine.throw

--- a/std/haxe/coro/Coroutine.hx
+++ b/std/haxe/coro/Coroutine.hx
@@ -2,6 +2,7 @@ package haxe.coro;
 
 import haxe.coro.EventLoop;
 import haxe.coro.schedulers.EventLoopScheduler;
+import haxe.coro.schedulers.Scheduler;
 import haxe.coro.continuations.RacingContinuation;
 import haxe.coro.continuations.BlockingContinuation;
 
@@ -32,13 +33,13 @@ abstract Coroutine<T:haxe.Constraints.Function> {
 
 	@:coroutine @:coroutine.nothrow public static function delay(ms:Int):Void {
 		Coroutine.suspend(cont -> {
-			cont.context.scheduler.scheduleIn(() -> cont.resume(null, null), ms);
+			cont.context.get(Scheduler.key).scheduleIn(() -> cont.resume(null, null), ms);
 		});
 	}
 
 	@:coroutine @:coroutine.nothrow public static function yield():Void {
 		Coroutine.suspend(cont -> {
-			cont.context.scheduler.schedule(() -> cont.resume(null, null));
+			cont.context.get(Scheduler.key).schedule(() -> cont.resume(null, null));
 		});
 	}
 

--- a/std/haxe/coro/CoroutineContext.hx
+++ b/std/haxe/coro/CoroutineContext.hx
@@ -1,9 +1,0 @@
-package haxe.coro;
-
-class CoroutineContext {
-    public final scheduler : IScheduler;
-
-    public function new(scheduler) {
-        this.scheduler = scheduler;
-    }
-}

--- a/std/haxe/coro/IContinuation.hx
+++ b/std/haxe/coro/IContinuation.hx
@@ -1,9 +1,10 @@
 package haxe.coro;
 
 import haxe.Exception;
+import haxe.coro.context.Context;
 
 interface IContinuation<T> {
-	final context:CoroutineContext;
+	final context:Context;
 
 	function resume(result:T, error:Exception):Void;
 }

--- a/std/haxe/coro/IScheduler.hx
+++ b/std/haxe/coro/IScheduler.hx
@@ -1,6 +1,0 @@
-package haxe.coro;
-
-interface IScheduler {
-    function schedule(func:() -> Void):Void;
-    function scheduleIn(func:() -> Void, ms:Int):Void;
-}

--- a/std/haxe/coro/context/Context.hx
+++ b/std/haxe/coro/context/Context.hx
@@ -1,23 +1,59 @@
 package haxe.coro.context;
 
-abstract Context(Array<Element>) {
-	public function new() {
-		this = [];
+import haxe.ds.BalancedTree;
+
+class ElementTree extends BalancedTree<Key<Any>, Element<Any>> {
+	override function compare(k1:Key<Any>, k2:Key<Any>) {
+		return k2.id - k1.id;
 	}
 
-	public function add<T:Element>(value:T) {
-		this[value.id] = value;
+	override function copy():ElementTree {
+		var copied = new ElementTree();
+		copied.root = root;
+		return copied;
+	}
+
+	override function toString() {
+		var buf = new StringBuf();
+		var first = true;
+		for (key => value in this) {
+			if (!first) {
+				buf.add(", ");
+			} else {
+				first = false;
+			}
+			buf.add('${key.name}: $value');
+		}
+		return buf.toString();
+	}
+}
+
+abstract Context(ElementTree) {
+	public function new(tree:ElementTree) {
+		this = tree;
+	}
+
+	public function add<T:Element<Any>>(value:T) {
+		this.set(value.id, value);
 	}
 
 	public function clone():Context {
-		return cast this;
+		return new Context(this.copy());
 	}
 
-	public function set<T:Element>(key:Key<T>, value:T):Void {
-		this[key.id] = value;
+	public function set<T:Element<V>, V>(key:Key<T>, value:T):Void {
+		this.set(key, value);
 	}
 
 	public function get<T>(key:Key<T>):T {
-		return cast this[key.id];
+		return cast this.get(key);
+	}
+
+	public function toString() {
+		return this.toString();
+	}
+
+	static public function empty() {
+		return new Context(new ElementTree());
 	}
 }

--- a/std/haxe/coro/context/Context.hx
+++ b/std/haxe/coro/context/Context.hx
@@ -1,0 +1,15 @@
+package haxe.coro.context;
+
+abstract Context(Array<Any>) {
+	public function new() {
+		this = [];
+	}
+
+	public function set<T>(key:Key<T>, value:T):Void {
+		this[key.id] = value;
+	}
+
+	public function get<T>(key:Key<T>):T {
+		return cast this[key.id];
+	}
+}

--- a/std/haxe/coro/context/Context.hx
+++ b/std/haxe/coro/context/Context.hx
@@ -1,8 +1,16 @@
 package haxe.coro.context;
 
-abstract Context(Array<Any>) {
+abstract Context(Array<Element>) {
 	public function new() {
 		this = [];
+	}
+
+	public function add<T:Element>(value:T) {
+		this[value.id] = value;
+	}
+
+	public function clone():Context {
+		return cast this;
 	}
 
 	public function set<T:Element>(key:Key<T>, value:T):Void {

--- a/std/haxe/coro/context/Context.hx
+++ b/std/haxe/coro/context/Context.hx
@@ -5,7 +5,7 @@ abstract Context(Array<Any>) {
 		this = [];
 	}
 
-	public function set<T>(key:Key<T>, value:T):Void {
+	public function set<T:Element>(key:Key<T>, value:T):Void {
 		this[key.id] = value;
 	}
 

--- a/std/haxe/coro/context/Element.hx
+++ b/std/haxe/coro/context/Element.hx
@@ -1,9 +1,11 @@
 package haxe.coro.context;
 
-abstract class Element {
-	public final id:Int;
+abstract class Element<T> {
+	public final id:Key<T>;
 
-	function new(id:Int) {
+	function new(id:Key<T>) {
 		this.id = id;
 	}
+
+	abstract public function toString():String;
 }

--- a/std/haxe/coro/context/Element.hx
+++ b/std/haxe/coro/context/Element.hx
@@ -1,0 +1,9 @@
+package haxe.coro.context;
+
+abstract class Element {
+	public final id:Int;
+
+	function new(id:Int) {
+		this.id = id;
+	}
+}

--- a/std/haxe/coro/context/Key.hx
+++ b/std/haxe/coro/context/Key.hx
@@ -1,0 +1,21 @@
+package haxe.coro.context;
+
+class Key<T> {
+	static var counter = 0;
+	static var counterMutex = new Mutex();
+
+	public final name:String;
+	public final id:Int;
+
+	function new(id:Int, name:String) {
+		this.name = name;
+		this.id = id;
+	}
+
+	static public function createNew<T>(name:String) {
+		counterMutex.acquire();
+		var id = counter++;
+		counterMutex.release();
+		return new Key<T>(id, name);
+	}
+}

--- a/std/haxe/coro/continuations/BlockingContinuation.hx
+++ b/std/haxe/coro/continuations/BlockingContinuation.hx
@@ -16,7 +16,7 @@ class BlockingContinuation<T> implements IContinuation<T> {
 	public function new(loop:EventLoop, scheduler:Scheduler) {
 		this.loop = loop;
 
-		context = new Context();
+		context = Context.empty();
 		context.set(Scheduler.key, scheduler);
 		running = true;
 		error = null;

--- a/std/haxe/coro/continuations/BlockingContinuation.hx
+++ b/std/haxe/coro/continuations/BlockingContinuation.hx
@@ -1,9 +1,11 @@
 package haxe.coro.continuations;
 
 import haxe.CallStack;
+import haxe.coro.context.Context;
+import haxe.coro.schedulers.Scheduler;
 
 class BlockingContinuation<T> implements IContinuation<T> {
-	public final context:CoroutineContext;
+	public final context:Context;
 
 	final loop:EventLoop;
 
@@ -11,10 +13,11 @@ class BlockingContinuation<T> implements IContinuation<T> {
 	var result:T;
 	var error:Exception;
 
-	public function new(loop, scheduler) {
+	public function new(loop:EventLoop, scheduler:Scheduler) {
 		this.loop = loop;
 
-		context = new CoroutineContext(scheduler);
+		context = new Context();
+		context.set(Scheduler.key, scheduler);
 		running = true;
 		error = null;
 	}

--- a/std/haxe/coro/continuations/RacingContinuation.hx
+++ b/std/haxe/coro/continuations/RacingContinuation.hx
@@ -1,5 +1,8 @@
 package haxe.coro.continuations;
 
+import haxe.coro.context.Context;
+import haxe.coro.schedulers.Scheduler;
+
 #if (target.threaded && !cppia)
 import sys.thread.Lock;
 import sys.thread.Mutex;
@@ -36,7 +39,7 @@ private class Thread {
 
 	var assigned:Bool;
 
-	public final context:CoroutineContext;
+	public final context:Context;
 
 	public function new(inputCont:IContinuation<T>, outputCont:SuspensionResult<T>) {
 		this.inputCont = inputCont;
@@ -47,7 +50,7 @@ private class Thread {
 	}
 
 	public function resume(result:T, error:Exception):Void {
-		context.scheduler.schedule(() -> {
+		context.get(Scheduler.key).schedule(() -> {
 			lock.acquire();
 
 			if (assigned) {

--- a/std/haxe/coro/schedulers/EventLoopScheduler.hx
+++ b/std/haxe/coro/schedulers/EventLoopScheduler.hx
@@ -18,4 +18,8 @@ class EventLoopScheduler extends Scheduler {
 	public function scheduleIn(func : ()->Void, ms:Int) {
 		loop.runIn(func, ms);
 	}
+
+	public function toString() {
+		return '[EventLoopScheduler: $loop]';
+	}
 }

--- a/std/haxe/coro/schedulers/EventLoopScheduler.hx
+++ b/std/haxe/coro/schedulers/EventLoopScheduler.hx
@@ -2,7 +2,8 @@ package haxe.coro.schedulers;
 
 import haxe.coro.EventLoop;
 
-class EventLoopScheduler implements IScheduler {
+class EventLoopScheduler extends Scheduler {
+
     final loop : EventLoop;
 
     public function new(loop) {

--- a/std/haxe/coro/schedulers/EventLoopScheduler.hx
+++ b/std/haxe/coro/schedulers/EventLoopScheduler.hx
@@ -6,7 +6,8 @@ class EventLoopScheduler extends Scheduler {
 
     final loop : EventLoop;
 
-    public function new(loop) {
+    public function new(loop:EventLoop) {
+		super();
         this.loop = loop;
     }
 

--- a/std/haxe/coro/schedulers/Scheduler.hx
+++ b/std/haxe/coro/schedulers/Scheduler.hx
@@ -3,11 +3,11 @@ package haxe.coro.schedulers;
 import haxe.coro.context.Key;
 import haxe.coro.context.Element;
 
-abstract class Scheduler extends Element {
-	public static final key:Key<Scheduler> = Key.createNew('_hx_scheduler');
+abstract class Scheduler extends Element<Scheduler> {
+	public static final key:Key<Scheduler> = Key.createNew('Scheduler');
 
 	function new() {
-		super(key.id);
+		super(key);
 	}
 
 	public abstract function schedule(func:() -> Void):Void;

--- a/std/haxe/coro/schedulers/Scheduler.hx
+++ b/std/haxe/coro/schedulers/Scheduler.hx
@@ -1,9 +1,14 @@
 package haxe.coro.schedulers;
 
 import haxe.coro.context.Key;
+import haxe.coro.context.Element;
 
-abstract class Scheduler {
+abstract class Scheduler extends Element {
 	public static final key:Key<Scheduler> = Key.createNew('_hx_scheduler');
+
+	function new() {
+		super(key.id);
+	}
 
 	public abstract function schedule(func:() -> Void):Void;
 

--- a/std/haxe/coro/schedulers/Scheduler.hx
+++ b/std/haxe/coro/schedulers/Scheduler.hx
@@ -1,0 +1,11 @@
+package haxe.coro.schedulers;
+
+import haxe.coro.context.Key;
+
+abstract class Scheduler {
+	public static final key:Key<Scheduler> = Key.createNew('_hx_scheduler');
+
+	public abstract function schedule(func:() -> Void):Void;
+
+	public abstract function scheduleIn(func:() -> Void, ms:Int):Void;
+}

--- a/tests/misc/coroutines/src/issues/aidan/Issue27.hx
+++ b/tests/misc/coroutines/src/issues/aidan/Issue27.hx
@@ -1,0 +1,46 @@
+package issues.aidan;
+import haxe.coro.context.Key;
+import haxe.coro.Coroutine;
+
+class DebugName {
+	static public var key:Key<{name:String}> = Key.createNew("_hx_debugName");
+}
+
+class Issue27 extends utest.Test {
+	function test() {
+		@:coroutine
+		function setDebug(name:String) {
+			Coroutine.suspend(cont -> {
+				cont.context.set(DebugName.key, {name: name});
+				cont.resume(null, null);
+			});
+		}
+
+		var log = [];
+
+		@:coroutine
+		function logDebug() {
+			Coroutine.suspend(cont -> {
+				log.push(cont.context.get(DebugName.key).name);
+				cont.resume(null, null);
+			});
+		}
+
+		@:coroutine
+		function modifyDebug(name:String) {
+			Coroutine.suspend(cont -> {
+				cont.context.get(DebugName.key).name = name;
+				cont.resume(null, null);
+			});
+		}
+		@:coroutine
+		function test() {
+			setDebug("first name");
+			logDebug();
+			modifyDebug("second name");
+			logDebug();
+			return log.join(", ");
+		}
+		Assert.equals("first name, second name", Coroutine.run(test));
+	}
+}

--- a/tests/misc/coroutines/src/issues/aidan/Issue27.hx
+++ b/tests/misc/coroutines/src/issues/aidan/Issue27.hx
@@ -3,14 +3,18 @@ import haxe.coro.context.Key;
 import haxe.coro.context.Element;
 import haxe.coro.Coroutine;
 
-class DebugName extends Element {
-	static public var key:Key<DebugName> = Key.createNew("_hx_debugName");
+class DebugName extends Element<DebugName> {
+	static public var key:Key<DebugName> = Key.createNew("DebugName");
 
 	public var name:String;
 
 	public function new(name:String) {
-		super(key.id);
+		super(key);
 		this.name = name;
+	}
+
+	public function toString() {
+		return '[DebugName: $name]';
 	}
 }
 

--- a/tests/misc/coroutines/src/issues/aidan/Issue27.hx
+++ b/tests/misc/coroutines/src/issues/aidan/Issue27.hx
@@ -1,9 +1,17 @@
 package issues.aidan;
 import haxe.coro.context.Key;
+import haxe.coro.context.Element;
 import haxe.coro.Coroutine;
 
-class DebugName {
-	static public var key:Key<{name:String}> = Key.createNew("_hx_debugName");
+class DebugName extends Element {
+	static public var key:Key<DebugName> = Key.createNew("_hx_debugName");
+
+	public var name:String;
+
+	public function new(name:String) {
+		super(key.id);
+		this.name = name;
+	}
 }
 
 class Issue27 extends utest.Test {
@@ -11,7 +19,7 @@ class Issue27 extends utest.Test {
 		@:coroutine
 		function setDebug(name:String) {
 			Coroutine.suspend(cont -> {
-				cont.context.set(DebugName.key, {name: name});
+				cont.context.set(DebugName.key, new DebugName(name));
 				cont.resume(null, null);
 			});
 		}


### PR DESCRIPTION
Updated version of https://github.com/Aidan63/haxe/commits/flexible_context/, using an `Array<Any>` as the core data structure.

I'm not adding any of this fancy operator overloading stuff because I don't really get what problem this solves. How exactly the API pans out depends on how all this is supposed to be used and I'm still in the dark about that. I did "port" the scheduler to use this though.

I also don't get why `Element` should be a thing. The only thing this seems to do is associate an object with a key, but I struggle to see in which situation this actually helps. We usually know which kind (Scheduler etc.) of data object we're dealing with, because otherwise we can't do anything with its semantics. The only case this seems to solve is "add this thing to the context but I don't know what it is".

For the keys themselves, I've opted to use `Key.createNew` which has the auto increment built-in. I have a suspicion that once we look into serializing coroutines, we need exact control over key numbers and might not always want to go through the increment mechanic.

This actually makes me realize that this whole `Array<Any>` approach comes with a certain problem: we could have a context with key 0 and key 1000, and a bunch of nothing inbetween. This could be solved with an additional indirection, but I'll have to think about this a bit more. 

Edit: I have no idea why CI fails, that doesn't seem to have to do with anything and doesn't reproduce for me locally...