### PR TITLE
[WIP] Stack traces continued

### DIFF
--- a/src/coro/coroToTexpr.ml
+++ b/src/coro/coroToTexpr.ml
@@ -184,7 +184,7 @@ let block_to_texpr_coroutine ctx cb cont cls params tf_args forbidden_vars exprs
 				   We assume that if we get a Thrown state with result == null, it was caused by
 				   an ImmediateSuspensionResult.
 				*)
-				(start_exception (b#bool false p))
+				(start_exception (b#int 2 p))
 				(b#assign eresult (* TODO: wrong type? *) estack)
 				com.basic.tvoid;
 			end;
@@ -271,9 +271,9 @@ let block_to_texpr_coroutine ctx cb cont cls params tf_args forbidden_vars exprs
 			add_state (Some (-1)) [ set_control CoroReturned; b#assign eresult e; ereturn ]
 		| NextThrow e1 ->
 			if ctx.throw then
-				add_state None ([stack_item_inserter e1.epos; start_exception (b#bool true p); b#throw e1])
+				add_state None ([stack_item_inserter e1.epos; start_exception (b#int 0 p); b#throw e1])
 			else
-				add_state None ([stack_item_inserter e1.epos; start_exception (b#bool true p); b#assign etmp e1; b#break p ])
+				add_state None ([stack_item_inserter e1.epos; start_exception (b#int 0 p); b#assign etmp e1; b#break p ])
 		| NextSub (cb_sub,cb_next) ->
 			add_state (Some cb_sub.cb_id) []
 
@@ -366,7 +366,7 @@ let block_to_texpr_coroutine ctx cb cont cls params tf_args forbidden_vars exprs
 				let vcaught = alloc_var VGenerated "e" t_dynamic p in
 				let ecaught = b#local vcaught p in
 				let e = b#void_block [
-					start_exception (b#bool false p);
+					start_exception (b#int 1 p);
 					b#assign etmp ecaught
 				] in
 				(vcaught,e)

--- a/src/coro/coroToTexpr.ml
+++ b/src/coro/coroToTexpr.ml
@@ -164,7 +164,7 @@ let block_to_texpr_coroutine ctx cb cont cls params tf_args forbidden_vars exprs
 		let base_continuation_field_on e cf t =
 			b#instance_field e com.basic.tcoro.suspension_result_class [com.basic.tany] cf t
 		in
-		let ecreatecoroutine = make_suspending_call com.basic call econtinuation in
+		let ecreatecoroutine = make_suspending_call com.basic call {econtinuation with epos = p} in
 
 		let vcororesult = alloc_var VGenerated "_hx_tmp" (com.basic.tcoro.suspension_result com.basic.tany) p in
 		let ecororesult = b#local vcororesult p in
@@ -177,7 +177,17 @@ let block_to_texpr_coroutine ctx cb cont cls params tf_args forbidden_vars exprs
 		] in
 		let ereturned = b#assign etmp (base_continuation_field_on ecororesult cont.result com.basic.tany) in
 		let ethrown = b#void_block [
-			b#assign eresult (* TODO: wrong type? *) (base_continuation_field_on ecororesult cont.result com.basic.tany);
+			begin
+				let estack = base_continuation_field_on ecororesult cont.result com.basic.tany in
+				b#if_then_else (b#op_eq estack (b#null estack.etype p))
+				(*
+				   We assume that if we get a Thrown state with result == null, it was caused by
+				   an ImmediateSuspensionResult.
+				*)
+				(start_exception (b#bool false p))
+				(b#assign eresult (* TODO: wrong type? *) estack)
+				com.basic.tvoid;
+			end;
 			b#assign etmp (base_continuation_field_on ecororesult cont.error cont.error.cf_type);
 			b#break p;
 		] in

--- a/std/haxe/coro/BaseContinuation.hx
+++ b/std/haxe/coro/BaseContinuation.hx
@@ -5,6 +5,23 @@ import haxe.coro.schedulers.Scheduler;
 import haxe.CallStack.StackItem;
 import haxe.Exception;
 
+private enum abstract ExceptionMode(Int) {
+	/**
+		The exception was raised by our own coroutine.
+	**/
+	var ExceptionSelf;
+	/**
+		The exception was raised further up the call stack, e.g. from a function
+		our current coroutine called.
+	**/
+	var ExceptionTop;
+	/**
+		The exception was created (but not raised) by a suspension function further
+		up the call stack and returned to our current coroutine.
+	**/
+	var ExceptionImmediate;
+}
+
 abstract class BaseContinuation<T> extends SuspensionResult<T> implements IContinuation<T> implements IStackFrame {
     public final completion:IContinuation<Any>;
 
@@ -15,6 +32,7 @@ abstract class BaseContinuation<T> extends SuspensionResult<T> implements IConti
     public var recursing:Bool;
 
 	var callStackOnFirstSuspension:Null<Array<StackItem>>;
+	var startedException:Bool;
 
     function new(completion:IContinuation<Any>, initialLabel:Int) {
         this.completion = completion;
@@ -24,6 +42,7 @@ abstract class BaseContinuation<T> extends SuspensionResult<T> implements IConti
         error      = null;
         result     = null;
         recursing  = false;
+		startedException = false;
     }
 
     public final function resume(result:Any, error:Exception):Void {
@@ -80,29 +99,47 @@ abstract class BaseContinuation<T> extends SuspensionResult<T> implements IConti
 		#end
     }
 
-	public function startException(fromThrow:Bool) {
+	public function startException(exceptionMode:ExceptionMode) {
+		startedException = true;
 		if (callStackOnFirstSuspension != null) {
+			/*
+				On the first suspension of any coroutine we record the synchronous call stack which tells
+				us how we got here. This will ensure we don't miss synchronous stack items, such as ones
+				from a TCOed parent function.
+
+				We skip the two topmost elements because they're from the set functions above and the call
+				to them from the state machine.
+			*/
 			callStackOnFirstSuspension = CallStackHelper.cullTopStack(callStackOnFirstSuspension, 2);
 		} else {
-			callStackOnFirstSuspension = [];
+			/**
+				This can only occur in ExceptionTop mode and means we caught a foreigh exception.
+			**/
+			result = cast callStackOnFirstSuspension = [];
+			return;
 		}
-		if (fromThrow) {
-			/*
-				This comes from a coro-level throw, which pushes its position via one of the functions
-				above. In this case we turn result into the stack item array now.
-			*/
-			callStackOnFirstSuspension.unshift(cast result);
-		} else {
-			/*
-				This means we caught an exception, which must come from outside our current coro. We
-				don't need our current result value because if anything it points to the last
-				suspension call.
-			*/
+		switch (exceptionMode) {
+			case ExceptionSelf | ExceptionImmediate:
+				/*
+					In these modes we add our current stack item as the topmost element to the call-stack.
+					In both cases the value will be set:
+						* A `throw` in Self mode is always preceeded by a call to one of the set functions above.
+						* Immediate mode only occurs after a suspension call, which also calls a set function.
+				*/
+				callStackOnFirstSuspension.unshift(cast result);
+			case ExceptionTop:
 		}
 		result = cast callStackOnFirstSuspension;
 	}
 
     public function buildCallStack() {
+		if (startedException) {
+			/*
+				If we started the exception in our current coroutine then we don't need to do any additional
+				management. The caller frame will be part of the top stack added by startException.
+			*/
+			return;
+		}
         var frame = callerFrame();
         if (frame != null) {
 			var result:Array<StackItem> = cast result;

--- a/std/haxe/coro/BaseContinuation.hx
+++ b/std/haxe/coro/BaseContinuation.hx
@@ -14,6 +14,8 @@ abstract class BaseContinuation<T> extends SuspensionResult<T> implements IConti
 
     public var recursing:Bool;
 
+	var callStackOnFirstSuspension:Null<Array<StackItem>>;
+
     function new(completion:IContinuation<Any>, initialLabel:Int) {
         this.completion = completion;
 
@@ -64,6 +66,7 @@ abstract class BaseContinuation<T> extends SuspensionResult<T> implements IConti
 
     public function setClassFuncStackItem(cls:String, func:String, file:String, line:Int, pos:Int, pmin:Int, pmax:Int) {
         result = cast StackItem.FilePos(StackItem.Method(cls, func), file, line, pos);
+		callStackOnFirstSuspension ??= CallStack.callStack();
 		#if eval
 		eval.vm.Context.callMacroApi("associate_enum_value_pos")(result, haxe.macro.Context.makePosition({file: file, min: pmin, max: pmax}));
 		#end
@@ -71,26 +74,32 @@ abstract class BaseContinuation<T> extends SuspensionResult<T> implements IConti
 
     public function setLocalFuncStackItem(id:Int, file:String, line:Int, pos:Int, pmin:Int, pmax:Int) {
         result = cast StackItem.FilePos(StackItem.LocalFunction(id), file, line, pos);
+		callStackOnFirstSuspension ??= CallStack.callStack();
 		#if eval
 		eval.vm.Context.callMacroApi("associate_enum_value_pos")(result, haxe.macro.Context.makePosition({file: file, min: pmin, max: pmax}));
 		#end
     }
 
 	public function startException(fromThrow:Bool) {
+		if (callStackOnFirstSuspension != null) {
+			callStackOnFirstSuspension = CallStackHelper.cullTopStack(callStackOnFirstSuspension, 2);
+		} else {
+			callStackOnFirstSuspension = [];
+		}
 		if (fromThrow) {
 			/*
 				This comes from a coro-level throw, which pushes its position via one of the functions
 				above. In this case we turn result into the stack item array now.
 			*/
-			result = cast [result];
+			callStackOnFirstSuspension.unshift(cast result);
 		} else {
 			/*
 				This means we caught an exception, which must come from outside our current coro. We
 				don't need our current result value because if anything it points to the last
 				suspension call.
 			*/
-			result = cast [];
 		}
+		result = cast callStackOnFirstSuspension;
 	}
 
     public function buildCallStack() {

--- a/std/haxe/coro/CallStackHelper.hx
+++ b/std/haxe/coro/CallStackHelper.hx
@@ -1,0 +1,25 @@
+package haxe.coro;
+
+import haxe.CallStack;
+
+class CallStackHelper {
+	static public function cullTopStack(items:Array<StackItem>, skip = 0) {
+		final topStack = [];
+		for (item in items) {
+			if (skip-- > 0) {
+				continue;
+			}
+			switch (item) {
+				// TODO: this needs a better check
+				case FilePos(_, _, -1, _):
+					break;
+				// this is a hack
+				case FilePos(Method(_, "invokeResume"), _):
+					break;
+				case _:
+					topStack.push(item);
+			}
+		}
+		return topStack;
+	}
+}

--- a/std/haxe/coro/ImmediateSuspensionResult.hx
+++ b/std/haxe/coro/ImmediateSuspensionResult.hx
@@ -14,7 +14,7 @@ class ImmediateSuspensionResult<T> extends SuspensionResult<T> {
 	}
 
 	static public function withError<T>(error:T) {
-		return new ImmediateSuspensionResult<T>(cast [] /* stack items */, @:privateAccess haxe.Exception.thrown(error));
+		return new ImmediateSuspensionResult<T>(null, @:privateAccess haxe.Exception.thrown(error));
 	}
 
 	public override function toString() {

--- a/std/haxe/coro/continuations/BlockingContinuation.hx
+++ b/std/haxe/coro/continuations/BlockingContinuation.hx
@@ -36,19 +36,7 @@ class BlockingContinuation<T> implements IContinuation<T> {
 
 		if (error != null) {
 			// trace((cast result : haxe.CallStack));
-			final topStack = [];
-			for (item in error.stack.asArray()) {
-				switch (item) {
-					// TODO: this needs a better check
-					case FilePos(_, _, -1, _):
-						break;
-					// this is a hack
-					case FilePos(Method(_, "invokeResume"), _):
-						break;
-					case _:
-						topStack.push(item);
-				}
-			}
+			final topStack = CallStackHelper.cullTopStack(error.stack.asArray());
 			final coroStack = (cast result : Array<StackItem>) ?? [];
 			final bottomStack = CallStack.callStack();
 			error.stack = topStack.concat(coroStack).concat(bottomStack);

--- a/std/haxe/coro/continuations/BlockingContinuation.hx
+++ b/std/haxe/coro/continuations/BlockingContinuation.hx
@@ -35,9 +35,24 @@ class BlockingContinuation<T> implements IContinuation<T> {
 		}
 
 		if (error != null) {
-			// trace((cast result : haxe.CallStack));
-			final topStack = CallStackHelper.cullTopStack(error.stack.asArray());
 			final coroStack = (cast result : Array<StackItem>) ?? [];
+			final coroTop = coroStack[0];
+			final topStack = [];
+			switch (coroStack[0]) {
+				case null:
+				case FilePos(_, file, line, _):
+					for (item in error.stack.asArray()) {
+						switch (item) {
+							case FilePos(_, file2, line2, _) if (file == file2 && line == line2):
+								break;
+							case FilePos(Method(_, "invokeResume"), _):
+								break;
+							case _:
+								topStack.push(item);
+						}
+					}
+				case _:
+			}
 			final bottomStack = CallStack.callStack();
 			error.stack = topStack.concat(coroStack).concat(bottomStack);
 			throw error;

--- a/tests/misc/coroutines/src/TestCallStack.hx
+++ b/tests/misc/coroutines/src/TestCallStack.hx
@@ -1,3 +1,5 @@
+import haxe.CallStack;
+import haxe.Exception;
 import callstack.CallStackInspector;
 
 class TestCallStack extends utest.Test {
@@ -6,7 +8,8 @@ class TestCallStack extends utest.Test {
 			callstack.Bottom.entry();
 			Assert.fail("Exception expected");
 		} catch(e:haxe.exceptions.NotImplementedException) {
-			var inspector = new CallStackInspector(e.stack.asArray());
+			final stack = e.stack.asArray();
+			var inspector = new CallStackInspector(stack);
 			var r = inspector.inspect([
 				File('callstack/Top.hx'),
 					Line(4),
@@ -14,9 +17,7 @@ class TestCallStack extends utest.Test {
 					Line(12),
 				File('callstack/CoroUpper.hx'),
 					Line(10),
-				#if hl
-					Line(5), // I still don't think this should be here
-				#end
+					Line(8), // TODO: I'm not sure if this should be here
 					Line(8),
 					Line(8),
 					Line(8),
@@ -29,15 +30,35 @@ class TestCallStack extends utest.Test {
 					Line(8),
 				Skip('callstack/Bottom.hx'),
 					Line(4)
-
 			]);
-			if (r == null) {
-				Assert.pass();
-			} else {
-				var i = 0;
-				var lines = e.stack.asArray().map(item -> '\t[${i++}] $item');
-				Assert.fail('${r.toString()}\n${lines.join("\n")}');
-			}
+			checkFailure(stack, r);
+		}
+	}
+
+	function checkFailure(stack:Array<StackItem>, r:Null<CallStackInspectorFailure>) {
+		if (r == null) {
+			Assert.pass();
+		} else {
+			var i = 0;
+			var lines = stack.map(item -> '\t[${i++}] $item');
+			Assert.fail('${r.toString()}\n${lines.join("\n")}');
+		}
+	}
+
+	function testFooBazBaz() {
+		try {
+			Coroutine.run(callstack.FooBarBaz.foo);
+			Assert.fail("Exception expected");
+		} catch(e:Exception) {
+			final stack = e.stack.asArray();
+			var inspector = new CallStackInspector(stack);
+			var r = inspector.inspect([
+				File('callstack/FooBarBaz.hx'),
+				Line(7),
+				Line(12),
+				Line(16)
+			]);
+			checkFailure(stack, r);
 		}
 	}
 }

--- a/tests/misc/coroutines/src/TestCallStack.hx
+++ b/tests/misc/coroutines/src/TestCallStack.hx
@@ -17,7 +17,6 @@ class TestCallStack extends utest.Test {
 					Line(12),
 				File('callstack/CoroUpper.hx'),
 					Line(10),
-					Line(8), // TODO: I'm not sure if this should be here
 					Line(8),
 					Line(8),
 					Line(8),
@@ -54,6 +53,11 @@ class TestCallStack extends utest.Test {
 			var inspector = new CallStackInspector(stack);
 			var r = inspector.inspect([
 				File('callstack/FooBarBaz.hx'),
+				#if (cpp && coroutine.noopt)
+				// TODO: cpp has inaccurate positions which causes the top stack to be wrong
+				Line(6),
+				Line(12),
+				#end
 				Line(7),
 				Line(12),
 				Line(16)

--- a/tests/misc/coroutines/src/callstack/FooBarBaz.hx
+++ b/tests/misc/coroutines/src/callstack/FooBarBaz.hx
@@ -1,0 +1,17 @@
+package callstack;
+
+import haxe.Exception;
+import haxe.coro.Coroutine.yield;
+
+@:coroutine function baz() {
+	throw new Exception('hello');
+}
+
+@:coroutine function bar() {
+	yield();
+	baz();
+}
+
+@:coroutine function foo() {
+	bar();
+}


### PR DESCRIPTION
Here's something that I thought should work but doesn't yet: upon encountering our first suspension call, i.e. when we're already calling `setClassFuncStackItem` or `setLocalFuncStackItem`, we grab and store the current call stack. This should always be the callstack of how we got into the current coro in a synchronous manner, which is what we want to report. We then cull it like we do with the top stack at the end, and compose everything together.

Given this example:

```haxe
import haxe.Exception;
import haxe.coro.IContinuation;
import haxe.coro.Coroutine;
import haxe.coro.Coroutine.delay;
import haxe.coro.Coroutine.yield;

@:coroutine function baz() {
	throw new Exception('hello');
}

@:coroutine function bar() {
	yield();
	baz();
}

@:coroutine function foo() {
	bar();
}

function main() {
	Coroutine.run(foo);
}
```

This gives us a pretty nice stack trace:

```
Exception in thread "main" hello
        at _Main.Main_Fields_.baz(source/Main.hx:8)
        at _Main.Main_Fields_.bar(source/Main.hx:13)
        at _Main.Main_Fields_.foo(source/Main.hx:17)
        at haxe.coro.continuations.BlockingContinuation.wait(C:\git\haxe\std/haxe/coro/continuations/BlockingContinuation.hx:41)
        at haxe.coro.Coroutine$Coroutine_Impl_.run(C:\git\haxe\std/haxe/coro/Coroutine.hx:53)
        at _Main.Main_Fields_.main(source/Main.hx:21)
        at _Main.Main_Fields_.main(source/Main.hx)
```

However, it's incorrect with `-D coroutine.noopt`:

```
Exception in thread "main" hello
        at _Main.Main_Fields_.baz(source/Main.hx:8)
        at _Main.Main_Fields_.bar(source/Main.hx:13)
        at _Main.Main_Fields_.baz(source/Main.hx:8)
        at _Main.Main_Fields_.bar(source/Main.hx:13)
        at _Main.Main_Fields_.bar(source/Main.hx:13)
        at _Main.Main_Fields_.foo(source/Main.hx:17)
        at haxe.coro.continuations.BlockingContinuation.wait(C:\git\haxe\std/haxe/coro/continuations/BlockingContinuation.hx:41)
        at haxe.coro.Coroutine$Coroutine_Impl_.run(C:\git\haxe\std/haxe/coro/Coroutine.hx:53)
        at _Main.Main_Fields_.main(source/Main.hx:21)
        at _Main.Main_Fields_.main(source/Main.hx)
```

The only good news is that the line numbers are all correct.