### PR TITLE
Remove -D coroutine.throw

### DIFF
--- a/src/coro/coro.ml
+++ b/src/coro/coro.ml
@@ -357,12 +357,8 @@ let coro_to_normal ctx coro_class cb_root exprs vcontinuation =
 				let e1 = coro_class.continuation_api.immediate_result e1 in
 				terminate (b#return e1);
 			| NextThrow e1 ->
-				if ctx.throw then
-					terminate (b#throw e1)
-				else begin
-					let e1 = coro_class.continuation_api.immediate_error e1 coro_class.inside.result_type in
-					terminate (b#return e1);
-				end
+				let e1 = coro_class.continuation_api.immediate_error e1 coro_class.inside.result_type in
+				terminate (b#return e1);
 			| NextUnknown | NextReturnVoid ->
 				let e1 = coro_class.continuation_api.immediate_result (b#null t_dynamic coro_class.name_pos) in
 				terminate (b#return e1);
@@ -430,7 +426,7 @@ let coro_to_normal ctx coro_class cb_root exprs vcontinuation =
 	in
 	let el,_ = loop cb_root [] in
 	let e = b#void_block el in
-	let e = if ctx.throw || ctx.nothrow then
+	let e = if ctx.nothrow then
 		e
 	else begin
 		let catch =
@@ -544,7 +540,6 @@ let create_coro_context typer meta =
 		coro_debug = Meta.has (Meta.Custom ":coroutine.debug") meta;
 		optimize;
 		allow_tco = optimize && not (Meta.has (Meta.Custom ":coroutine.notco") meta);
-		throw = Define.raw_defined typer.com.defines "coroutine.throw";
 		nothrow = Meta.has (Meta.Custom ":coroutine.nothrow") meta;
 		vthis = None;
 		next_block_id = 0;

--- a/src/coro/coroToTexpr.ml
+++ b/src/coro/coroToTexpr.ml
@@ -207,9 +207,7 @@ let block_to_texpr_coroutine ctx cb cont cls params tf_args forbidden_vars exprs
 			die "" __LOC__
 	in
 	let eif_error =
-		let el = if ctx.throw then
-			[b#throw eerror]
-		else [
+		let el = [
 			b#assign etmp eerror;
 			b#break p;
 		] in
@@ -260,10 +258,7 @@ let block_to_texpr_coroutine ctx cb cont cls params tf_args forbidden_vars exprs
 		| NextReturn e ->
 			add_state (Some (-1)) [ set_control CoroReturned; b#assign eresult e; ereturn ]
 		| NextThrow e1 ->
-			if ctx.throw then
-				add_state None ([b#assign etmp e1; stack_item_inserter e1.epos; start_exception (wrap_thrown etmp); b#throw etmp])
-			else
-				add_state None ([b#assign etmp e1; stack_item_inserter e1.epos; start_exception (wrap_thrown etmp); b#break p ])
+			add_state None ([b#assign etmp e1; stack_item_inserter e1.epos; start_exception (wrap_thrown etmp); b#break p ])
 		| NextSub (cb_sub,cb_next) ->
 			add_state (Some cb_sub.cb_id) []
 
@@ -347,7 +342,7 @@ let block_to_texpr_coroutine ctx cb cont cls params tf_args forbidden_vars exprs
 
 	let eloop = mk (TWhile (b#bool true p, eswitch, NormalWhile)) com.basic.tvoid p in
 
-	let etry = if ctx.nothrow || (ctx.throw && not ctx.has_catch) then
+	let etry = if ctx.nothrow then
 		eloop
 	else
 		mk (TTry (
@@ -376,9 +371,7 @@ let block_to_texpr_coroutine ctx cb cont cls params tf_args forbidden_vars exprs
 				] in
 				DynArray.add cases {case_patterns = patterns; case_expr = expr};
 		) exc_state_map;
-		let el = if ctx.throw then [
-			b#throw etmp
-		] else begin
+		let el =
 			let field         = PMap.find "buildCallStack" com.basic.tcoro.base_continuation_class.cl_fields in
 			let eaccess       = b#instance_field econtinuation com.basic.tcoro.base_continuation_class params field field.cf_type in
 			let ewrapped_call = mk (TCall (eaccess, [ ])) com.basic.tvoid p in
@@ -388,7 +381,7 @@ let block_to_texpr_coroutine ctx cb cont cls params tf_args forbidden_vars exprs
 				set_control CoroThrown;
 				ereturn;
 			]
-		end in
+		in
 		let default = b#void_block el in
 		if DynArray.empty cases then
 			default

--- a/src/coro/coroTypes.ml
+++ b/src/coro/coroTypes.ml
@@ -54,7 +54,6 @@ type coro_ctx = {
 	coro_debug : bool;
 	optimize : bool;
 	allow_tco : bool;
-	throw : bool;
 	nothrow : bool;
 	mutable vthis : tvar option;
 	mutable next_block_id : int;

--- a/tests/runci/tests/CoroutineTests.hx
+++ b/tests/runci/tests/CoroutineTests.hx
@@ -8,13 +8,11 @@ class CoroutineTests {
 		infoMsg("Test coroutines:");
 		changeDirectory(getMiscSubDir("coroutines"));
 		for (opt in [[], ["-D", "coroutine.noopt"]]) {
-			for (thro in [[], ["-D", "coroutine.throw"]]) {
-				var args = baseArgs.concat(opt).concat(thro);
-				infoMsg("Running " + args.join(" "));
-				runCommand("haxe", args);
-				if (afterwards != null) {
-					afterwards(args);
-				}
+			var args = baseArgs.concat(opt);
+			infoMsg("Running " + args.join(" "));
+			runCommand("haxe", args);
+			if (afterwards != null) {
+				afterwards(args);
 			}
 		}
 	}


### PR DESCRIPTION
This causes too many distractions and won't work properly with structured concurrency anyway, and it also doesn't really solve any problems. We'll deal with the debugger problem "later".