### PR TITLE
Add Created state and lambda to BaseCoroutine

### DIFF
--- a/std/haxe/coro/Coroutine.hx
+++ b/std/haxe/coro/Coroutine.hx
@@ -9,6 +9,8 @@ import haxe.coro.continuations.RacingContinuation;
 import haxe.coro.continuations.BlockingContinuation;
 import haxe.exceptions.NotImplementedException;
 
+typedef ScopedCoroutine<T> = Coroutine<(scope:ICoroutineScope) -> T>;
+
 private class CoroSuspend<T> extends haxe.coro.BaseContinuation<T> {
 	public function new(completion:haxe.coro.IContinuation<T>) {
 		super(completion, 1);
@@ -65,17 +67,8 @@ abstract Coroutine<T:haxe.Constraints.Function> {
 
 	public static function runScoped<T>(f:Coroutine<(scope : ICoroutineScope)->T>):T {
 		final loop   = new EventLoop();
-		final cont   = new BlockingCoroutine(loop);
-		final result = f(cont, cont);
-
-		switch (result.state) {
-			case Pending:
-				//
-			case Returned:
-				cont.resume(result.result, null);
-			case Thrown:
-				cont.resume(null, result.error);
-		}
+		final cont   = new BlockingCoroutine(loop, f);
+		cont.launch();
 
 		return cont.wait();
 	}
@@ -83,17 +76,8 @@ abstract Coroutine<T:haxe.Constraints.Function> {
 	@:coroutine public static function scope<T>(f:Coroutine<(scope : ICoroutineScope)->T>):T {
 		return Coroutine.suspend(cont -> {
 			final coro   = cont.context.get(key);
-			final child  = coro.child(cont.context);
-			final result = f(child, child);
-
-			switch result.state {
-				case Pending:
-					//
-				case Returned:
-					child.complete(result.result);
-				case Thrown:
-					child.completeExceptionally(result.error);
-			}
+			final child  = coro.child(cont.context, f);
+			child.launch();
 
 			child.onCompletion(() -> {
 				switch child.state {

--- a/std/haxe/coro/ICoroutine.hx
+++ b/std/haxe/coro/ICoroutine.hx
@@ -2,6 +2,7 @@ package haxe.coro;
 
 import haxe.coro.context.Context;
 import haxe.coro.coroutines.BaseCoroutine;
+import haxe.coro.Coroutine;
 
 interface ICoroutine<T> {
 	var isRunning (get, never) : Bool;
@@ -14,5 +15,5 @@ interface ICoroutine<T> {
 
 	function cancel() : Void;
 
-	function child(context:Context) : BaseCoroutine<T>;
+	function child(context:Context, lambda:ScopedCoroutine<T>) : BaseCoroutine<T>;
 }

--- a/std/haxe/coro/coroutines/BaseCoroutine.hx
+++ b/std/haxe/coro/coroutines/BaseCoroutine.hx
@@ -6,8 +6,13 @@ import haxe.coro.schedulers.Scheduler;
 import haxe.coro.context.IElement;
 import haxe.coro.context.Context;
 import haxe.coro.scopes.ScopeComponent;
+import haxe.coro.Coroutine;
 
 private enum abstract CoroutineState(Int) {
+	/**
+		The coroutine itself is still running.
+	**/
+	final Created;
 	/**
 		The coroutine itself is still running.
 	**/
@@ -41,7 +46,7 @@ class AdjustedContext<T> implements ICoroutineScope {
 
 	@:access(haxe.coro.coroutines.BaseCoroutine)
 	public function start<T>(c:Coroutine<ICoroutineScope->T>):ICoroutine<T> {
-		return coroutine.startChild(c, coroutine.child(context));
+		return coroutine.startChild(coroutine.child(context, c));
 	}
 
 	public function with(...elements:IElement<Any>) {
@@ -64,19 +69,39 @@ class BaseCoroutine<T> implements IElement<ICoroutine<Any>> implements ICoroutin
 
 	public var state : CoroutineState;
 
+	var lambda : ScopedCoroutine<T>;
+
 	final children : Array<BaseCoroutine<Any>>;
 
 	var completionCallbacks : Array<()->Void>;
 
 	var completedChildren : Int;
 
-	public function new(context : Context) {
+	public function new(context : Context, lambda : ScopedCoroutine<T>) {
 		this.context  = context.clone().with(this);
 		this.children = [];
 
+		this.lambda         = lambda;
 		completionCallbacks = [];
 		completedChildren   = 0;
-		state               = Running;
+		state               = Created;
+	}
+
+	public function launch() {
+		switch (state) {
+			case Created:
+				state = Running;
+				final result = lambda(this, this);
+				switch result.state {
+					case Pending:
+						return;
+					case Returned:
+						resume(result.result, null);
+					case Thrown:
+						resume(null, result.error);
+				}
+			case _:
+		}
 	}
 
 	@:coroutine public function await() : T {
@@ -107,8 +132,8 @@ class BaseCoroutine<T> implements IElement<ICoroutine<Any>> implements ICoroutin
 		}
 	}
 
-	public function child<T>(context:Context) {
-		final coroutine = new BaseCoroutine<T>(context);
+	public function child<T>(context:Context, lambda:ScopedCoroutine<T>) {
+		final coroutine = new BaseCoroutine<T>(context, lambda);
 
 		coroutine.onCompletion(() -> {
 			completedChildren++;
@@ -124,10 +149,10 @@ class BaseCoroutine<T> implements IElement<ICoroutine<Any>> implements ICoroutin
 	}
 
 	public function start<T>(c:Coroutine<ICoroutineScope->T>):ICoroutine<T> {
-		return startChild(c, child(context));
+		return startChild(child(context, c));
 	}
 
-	function startChild<T>(c:Coroutine<ICoroutineScope->T>, coroutine:BaseCoroutine<T>):ICoroutine<T> {
+	function startChild<T>(coroutine:BaseCoroutine<T>):ICoroutine<T> {
 
 		coroutine.onCompletion(() -> context.get(ScopeComponent.key).onCompletion(this, coroutine));
 
@@ -140,16 +165,7 @@ class BaseCoroutine<T> implements IElement<ICoroutine<Any>> implements ICoroutin
 				return;
 			}
 
-			final result = c(coroutine, coroutine);
-
-			switch result.state {
-				case Pending:
-					return;
-				case Returned:
-					coroutine.complete(result.result);
-				case Thrown:
-					coroutine.completeExceptionally(result.error);
-			}
+			coroutine.launch();
 		});
 
 		return coroutine;
@@ -217,7 +233,7 @@ class BaseCoroutine<T> implements IElement<ICoroutine<Any>> implements ICoroutin
 
 	function get_isRunning() {
 		return switch state {
-			case Running: true;
+			case Created | Running: true;
 			case _: false;
 		}
 	}

--- a/std/haxe/coro/coroutines/BlockingCoroutine.hx
+++ b/std/haxe/coro/coroutines/BlockingCoroutine.hx
@@ -2,14 +2,15 @@ package haxe.coro.coroutines;
 
 import haxe.coro.context.Context;
 import haxe.coro.scopes.DefaultScopeComponent;
+import haxe.coro.Coroutine;
 import haxe.CallStack.StackItem;
 import haxe.coro.schedulers.EventLoopScheduler;
 
 class BlockingCoroutine<T> extends BaseCoroutine<T> {
 	final loop : EventLoop;
 
-	public function new(loop : EventLoop) {
-		super(Context.create(new DefaultScopeComponent(), new EventLoopScheduler(loop), new BaseContinuation.StackTraceManager()));
+	public function new(loop : EventLoop, lambda : ScopedCoroutine<T>) {
+		super(Context.create(new DefaultScopeComponent(), new EventLoopScheduler(loop), new BaseContinuation.StackTraceManager()), lambda);
 
 		this.loop = loop;
 

--- a/std/haxe/coro/scopes/DefaultScopeComponent.hx
+++ b/std/haxe/coro/scopes/DefaultScopeComponent.hx
@@ -9,7 +9,7 @@ class DefaultScopeComponent extends ScopeComponent {
 
 	public function cancel(coroutine:BaseCoroutine<Any>) {
 		switch coroutine.state {
-			case Running:
+			case Created | Running:
 				coroutine.completeExceptionally(new CancellationException());
 			case Completing:
 				coroutine.state = Cancelling;
@@ -46,7 +46,7 @@ class DefaultScopeComponent extends ScopeComponent {
 		}
 
 		// All children have completed but the scopes block is still running, so exit.
-		if (coroutine.state == Running) {
+		if (coroutine.isRunning) {
 			return;
 		}
 

--- a/tests/misc/coroutines/src/structured/TestThrowingScopes.hx
+++ b/tests/misc/coroutines/src/structured/TestThrowingScopes.hx
@@ -70,7 +70,7 @@ class TestThrowingScopes extends utest.Test {
 			Coroutine.runScoped(scope -> {
 				final child = scope.start(scope -> {
 					yield();
-	
+
 					throw new FooException();
 				});
 
@@ -84,7 +84,7 @@ class TestThrowingScopes extends utest.Test {
 			Coroutine.runScoped(scope -> {
 				final child = scope.start(scope -> {
 					delay(1000);
-	
+
 					throw new FooException();
 				});
 
@@ -123,5 +123,18 @@ class TestThrowingScopes extends utest.Test {
 				child.cancel();
 			});
 		}, CancellationException);
+	}
+
+	function test_catching_child_exception() {
+		var caught = false;
+		Assert.raises(() -> Coroutine.runScoped(function(scope) {
+			final child = scope.start(_ -> throw new FooException());
+			try {
+				child.await();
+			} catch (e:FooException) {
+				caught = true;
+			}
+		}), FooException);
+		Assert.isTrue(caught);
 	}
 }


### PR DESCRIPTION
This associates a `BaseCoroutine` with the suspension lambda and initially sets the state to `Created`. It is set to `Running` when `launch` is called. This will allow the creation of lazy coroutines that don't start immediately.

I'm not adding any actual `create` method yet because I want to take really small steps here.