### PR TITLE
Fix continuation name clash

### DIFF
--- a/src/coro/coro.ml
+++ b/src/coro/coro.ml
@@ -50,7 +50,7 @@ module ContinuationClassBuilder = struct
 			let captured_field_name = "captured" in
 			match coro_type with
 			| ClassField (cls, field, tf, _) ->
-				Printf.sprintf "HxCoro_%s_%s_%s" (ctx.typer.m.curmod.m_path |> fst |> String.concat "_") (ctx.typer.m.curmod.m_path |> snd) field.cf_name,
+				Printf.sprintf "HxCoro_%s_%s_%s" (cls.cl_path |> fst |> String.concat "_") (cls.cl_path |> snd) field.cf_name,
 				(if has_class_field_flag field CfStatic then
 					None
 				else

--- a/tests/misc/coroutines/src/issues/aidan/Issue91.hx
+++ b/tests/misc/coroutines/src/issues/aidan/Issue91.hx
@@ -1,0 +1,27 @@
+package issues.aidan;
+
+import haxe.coro.Coroutine;
+
+class C1 {
+	public function new() {}
+
+	@:coroutine public function await() {}
+}
+
+class C2 {
+	public function new() {}
+
+	@:coroutine public function await() {}
+}
+
+class Issue91 extends utest.Test {
+	function test() {
+		final c1 = new C1();
+		final c2 = new C2();
+		Coroutine.run(() -> {
+			c1.await();
+			c2.await();
+		});
+		Assert.pass();
+	}
+}


### PR DESCRIPTION
Closes #91, the name mangling was still using the typers current module path for the mangling.