### PR TITLE
Prompt cancellation

### DIFF
--- a/std/haxe/coro/cancellation/CancellationToken.hx
+++ b/std/haxe/coro/cancellation/CancellationToken.hx
@@ -1,0 +1,32 @@
+package haxe.coro.cancellation;
+
+import haxe.coro.context.Key;
+
+private class NoOpCancellationHandle implements ICancellationHandle {
+	public function new() {}
+	public function close() {}
+}
+
+private class NoOpCancellationToken implements ICancellationToken {
+	static final handle = new NoOpCancellationHandle();
+
+	public var isCancellationRequested (get, never) : Bool;
+
+	public function new() {}
+
+	public function onCancellationRequested(func:() -> Void):ICancellationHandle {
+		return handle;
+	}
+	public function get_isCancellationRequested() {
+		return false;
+	}
+}
+
+class CancellationToken {
+	public static final key : Key<ICancellationToken> = Key.createNew('CancellationToken');
+
+	/**
+	 * Returns a cancellation token which will never be cancelled.
+	 */
+	public static final none : ICancellationToken = new NoOpCancellationToken();
+}

--- a/std/haxe/coro/cancellation/ICancellationHandle.hx
+++ b/std/haxe/coro/cancellation/ICancellationHandle.hx
@@ -1,0 +1,5 @@
+package haxe.coro.cancellation;
+
+interface ICancellationHandle {
+	function close():Void;
+}

--- a/std/haxe/coro/cancellation/ICancellationHandle.hx
+++ b/std/haxe/coro/cancellation/ICancellationHandle.hx
@@ -1,5 +1,13 @@
 package haxe.coro.cancellation;
 
+/**
+ * Handle to a callback which has been registered with a cancellation token.
+ */
 interface ICancellationHandle {
+	/**
+	 * Stops the callback from being executed when the token is cancelled.
+	 * If the token is already cancelled this function does nothing.
+	 * This function is safe to call multiple times and is thread safe.
+	 */
 	function close():Void;
 }

--- a/std/haxe/coro/cancellation/ICancellationToken.hx
+++ b/std/haxe/coro/cancellation/ICancellationToken.hx
@@ -1,0 +1,7 @@
+package haxe.coro.cancellation;
+
+interface ICancellationToken {
+	var isCancellationRequested (get, never) : Bool;
+
+	function onCancellationRequested(func : ()->Void) : ICancellationHandle;
+}

--- a/std/haxe/coro/cancellation/ICancellationToken.hx
+++ b/std/haxe/coro/cancellation/ICancellationToken.hx
@@ -1,7 +1,21 @@
 package haxe.coro.cancellation;
 
+/**
+ * A cancellation token enables cooperative cancellation between units of work (threads, coroutines, etc).
+ * The token cannot be used to initiate cancellation, only to poll for a cancellation request or register a callback for when cancellation is requested.
+ * Cancellation is cooperative which means it is up to the caller to respond to a cancellation request in a manner it deems best.
+ * Access to this interface is thread safe.
+ */
 interface ICancellationToken {
 	var isCancellationRequested (get, never) : Bool;
 
+	/**
+	 * Register a callback which will be executed when this token is cancelled.
+	 * 
+	 * If this token has already been cancelled the function will be executed immediately and synchronously, any exception raised will not be caught.
+	 * The thread the callback is executed on is implementation defined if cancellation has not been yet been requested.
+	 * @param func Callback to be executed when the token is cancelled.
+	 * @return Cancellation handle which can be used to cancel the callback from executing.
+	 */
 	function onCancellationRequested(func : ()->Void) : ICancellationHandle;
 }

--- a/std/haxe/coro/schedulers/EventLoopScheduler.hx
+++ b/std/haxe/coro/schedulers/EventLoopScheduler.hx
@@ -3,20 +3,46 @@ package haxe.coro.schedulers;
 import haxe.exceptions.ArgumentException;
 
 private typedef Lambda = ()->Void;
+private typedef CloseClosure = (handle:ISchedulerHandle)->Void;
 
-private class ScheduledEvent {
-	public final func : Lambda;
+private class ScheduledEvent implements ISchedulerHandle {
+	final closure : CloseClosure;
+	final func : Lambda;
+	var closed : Bool;
 	public final runTime : Float;
 	public var next : Null<ScheduledEvent>;
 	public var previous : Null<ScheduledEvent>;
 
-	public function new(func, runTime) {
+	public function new(closure, func, runTime) {
+		this.closure = closure;
 		this.func    = func;
 		this.runTime = runTime;
 
+		closed   = false;
 		next     = null;
 		previous = null;
 	}
+
+	public inline function run() {
+		func();
+
+		closed = true;
+	}
+
+	public function close() {
+		if (closed) {
+			return;
+		}
+
+		closure(this);
+
+		closed = true;
+	}
+}
+
+private class NoOpHandle implements ISchedulerHandle {
+	public function new() {}
+	public function close() {}
 }
 
 private class DoubleBuffer {
@@ -53,29 +79,33 @@ class EventLoopScheduler extends Scheduler {
 	var first : Null<ScheduledEvent>;
 	var last : Null<ScheduledEvent>;
 
+	final noOpHandle : NoOpHandle;
 	final zeroEvents : DoubleBuffer;
+	final closeClosure : CloseClosure;
 
 	public function new() {
 		super();
 
-		first = null;
-		last = null;
-		zeroEvents = new DoubleBuffer();
+		first        = null;
+		last         = null;
+		noOpHandle   = new NoOpHandle();
+		zeroEvents   = new DoubleBuffer();
+		closeClosure = close;
 	}
 
-    public function schedule(ms:Int, func:()->Void) {
+    public function schedule(ms:Int, func:()->Void):ISchedulerHandle {
 		if (ms < 0) {
 			throw new ArgumentException("Time must be greater or equal to zero");
 		} else if (ms == 0) {
 			zeroEvents.push(func);
-			return;
+			return noOpHandle;
 		}
 
-		final event = new ScheduledEvent(func, now() + (ms / 1000));
+		final event = new ScheduledEvent(closeClosure, func, now() + (ms / 1000));
 		if (first == null) {
 			first = event;
 			last = event;
-			return;
+			return event;
 		}
 
 		var current = last;
@@ -83,7 +113,7 @@ class EventLoopScheduler extends Scheduler {
 			if (current == null) {
 				event.next = first;
 				first = event;
-				break;
+				return event;
 			} else if (event.runTime >= current.runTime) {
 				final next = current.next;
 				current.next = event;
@@ -94,7 +124,7 @@ class EventLoopScheduler extends Scheduler {
 				} else {
 					last = event;
 				}
-				break;
+				return event;
 			} else {
 				current = current.previous;
 			}
@@ -119,12 +149,12 @@ class EventLoopScheduler extends Scheduler {
 					break;
 				}
 				if (first.runTime <= currentTime) {
-					final func = first.func;
+					final toRun = first;
 					first = first.next;
 					if (first != null) {
 						first.previous = null;
 					}
-					func();
+					toRun.run();
 				} else {
 					break;
 				}
@@ -137,5 +167,30 @@ class EventLoopScheduler extends Scheduler {
 
 	public function toString() {
 		return '[EventLoopScheduler]';
+	}
+
+	function close(handle : ISchedulerHandle) {
+		var current = first;
+		while (true) {
+			if (null == current) {
+				return;
+			}
+
+			if (current == handle) {
+				if (first == current) {
+					first = current.next;
+				} else {
+					final a = current.previous;
+					final b = current.next;
+	
+					a.next = b;
+					b.previous = a;
+				}
+
+				return;
+			} else {
+				current = current.next;
+			}
+		}
 	}
 }

--- a/std/haxe/coro/schedulers/ISchedulerHandle.hx
+++ b/std/haxe/coro/schedulers/ISchedulerHandle.hx
@@ -1,0 +1,13 @@
+package haxe.coro.schedulers;
+
+/**
+ * Handle representing a scheduled function.
+ */
+interface ISchedulerHandle {
+	/**
+	 * Close the handle thereby cancelleting future execution of the scheduled function.
+	 * If the function is currently executing or has already executed nothing happens.
+	 * This function is thread safe and allowed to be called multiple times.
+	 */
+	function close() : Void;
+}

--- a/std/haxe/coro/schedulers/Scheduler.hx
+++ b/std/haxe/coro/schedulers/Scheduler.hx
@@ -8,7 +8,7 @@ abstract class Scheduler implements IElement<Scheduler> {
 
 	function new() {}
 
-	public abstract function schedule(ms:Int, func:() -> Void):Void;
+	public abstract function schedule(ms:Int, func:() -> Void):ISchedulerHandle;
 
 	public abstract function now():Float;
 

--- a/std/haxe/coro/schedulers/VirtualTimeScheduler.hx
+++ b/std/haxe/coro/schedulers/VirtualTimeScheduler.hx
@@ -46,13 +46,13 @@ class VirtualTimeScheduler extends EventLoopScheduler {
 					break;
 				}
 				if (first.runTime <= endTime) {
-					final func = first.func;
+					final toRun = first;
 					currentTime = first.runTime;
 					first = first.next;
 					if (first != null) {
 						first.previous = null;
 					}
-					func();
+					toRun.run();
 				} else {
 					break;
 				}

--- a/std/hxcoro/AbstractTask.hx
+++ b/std/hxcoro/AbstractTask.hx
@@ -1,5 +1,7 @@
 package hxcoro;
 
+import haxe.coro.cancellation.ICancellationToken;
+import haxe.coro.cancellation.ICancellationHandle;
 import haxe.exceptions.CancellationException;
 import haxe.Exception;
 
@@ -12,24 +14,45 @@ enum abstract TaskState(Int) {
 	final Cancelled;
 }
 
-class TaskException extends Exception {}
+private class TaskException extends Exception {}
 
-class CancellationHandle {
+private class CancellationHandle implements ICancellationHandle {
 	final func : ()->Void;
 	final all : Array<CancellationHandle>;
+
+	var closed : Bool;
 
 	public function new(func, all) {
 		this.func = func;
 		this.all  = all;
+
+		closed = false;
 	}
 
 	public function run() {
+		if (closed) {
+			return;
+		}
+
 		func();
+
+		closed = true;
 	}
 
 	public function close() {
+		if (closed) {
+			return;
+		}
+
 		all.remove(this);
+
+		closed = true;
 	}
+}
+
+private class NoOpCancellationHandle implements ICancellationHandle {
+	public function new() {}
+	public function close() {}
 }
 
 /**
@@ -39,13 +62,25 @@ class CancellationHandle {
 	and should be kept in a state where it could even be moved outside the hxcoro package. Also, `state` should
 	be treated like a truly private variable and only be modified from within this class.
 **/
-abstract class AbstractTask<T> {
+abstract class AbstractTask<T> implements ICancellationToken {
 	final children:Array<AbstractTask<Any>>;
 	final cancellationCallbacks:Array<CancellationHandle>;
+	final noOpCancellationHandle:NoOpCancellationHandle;
 	var state:TaskState;
 	var error:Null<Exception>;
 	var numCompletedChildren:Int;
 	var indexInParent:Int;
+
+	public var isCancellationRequested (get, never) : Bool;
+
+	inline function get_isCancellationRequested() {
+		return switch state {
+			case Cancelling | Cancelled:
+				true;
+			case _:
+				false;
+		}
+	}
 
 	/**
 		Creates a new task.
@@ -56,6 +91,7 @@ abstract class AbstractTask<T> {
 		cancellationCallbacks = [];
 		numCompletedChildren = 0;
 		indexInParent = -1;
+		noOpCancellationHandle = new NoOpCancellationHandle();
 	}
 
 	/**
@@ -106,26 +142,12 @@ abstract class AbstractTask<T> {
 		}
 	}
 
-	/**
-		Returns `true` if cancellation has been requested. This remains true even if cancellation has completed.
-	**/
-	public function cancellationRequested() {
-		return switch (state) {
-			case Cancelling | Cancelled:
-				true;
-			case _:
-				false;
-		}
-	}
-
-	public function onCancellationRequested(f:()->Void) {
+	public function onCancellationRequested(f:()->Void):ICancellationHandle {
 		return switch state {
 			case Cancelling | Cancelled:
 				f();
 
-				// todo have some sort of no op handle again.
-
-				new CancellationHandle(f, cancellationCallbacks);
+				return noOpCancellationHandle;
 			case _:
 				final handle = new CancellationHandle(f, cancellationCallbacks);
 

--- a/std/hxcoro/AbstractTask.hx
+++ b/std/hxcoro/AbstractTask.hx
@@ -63,9 +63,10 @@ private class NoOpCancellationHandle implements ICancellationHandle {
 	be treated like a truly private variable and only be modified from within this class.
 **/
 abstract class AbstractTask<T> implements ICancellationToken {
+	static final noOpCancellationHandle = new NoOpCancellationHandle();
+
 	final children:Array<AbstractTask<Any>>;
 	final cancellationCallbacks:Array<CancellationHandle>;
-	final noOpCancellationHandle:NoOpCancellationHandle;
 	var state:TaskState;
 	var error:Null<Exception>;
 	var numCompletedChildren:Int;
@@ -91,7 +92,6 @@ abstract class AbstractTask<T> implements ICancellationToken {
 		cancellationCallbacks = [];
 		numCompletedChildren = 0;
 		indexInParent = -1;
-		noOpCancellationHandle = new NoOpCancellationHandle();
 	}
 
 	/**

--- a/std/hxcoro/AbstractTask.hx
+++ b/std/hxcoro/AbstractTask.hx
@@ -65,8 +65,8 @@ private class NoOpCancellationHandle implements ICancellationHandle {
 abstract class AbstractTask<T> implements ICancellationToken {
 	static final noOpCancellationHandle = new NoOpCancellationHandle();
 
-	final children:Array<AbstractTask<Any>>;
-	final cancellationCallbacks:Array<CancellationHandle>;
+	var children:Null<Array<AbstractTask<Any>>>;
+	var cancellationCallbacks:Null<Array<CancellationHandle>>;
 	var state:TaskState;
 	var error:Null<Exception>;
 	var numCompletedChildren:Int;
@@ -88,8 +88,8 @@ abstract class AbstractTask<T> implements ICancellationToken {
 	**/
 	public function new() {
 		state = Created;
-		children = [];
-		cancellationCallbacks = [];
+		children = null;
+		cancellationCallbacks = null;
 		numCompletedChildren = 0;
 		indexInParent = -1;
 	}
@@ -118,8 +118,10 @@ abstract class AbstractTask<T> implements ICancellationToken {
 				}
 				state = Cancelling;
 
-				for (h in cancellationCallbacks) {
-					h.run();
+				if (null != cancellationCallbacks) {
+					for (h in cancellationCallbacks) {
+						h.run();
+					}
 				}
 
 				cancelChildren(cause);
@@ -149,6 +151,9 @@ abstract class AbstractTask<T> implements ICancellationToken {
 
 				return noOpCancellationHandle;
 			case _:
+				if (null == cancellationCallbacks) {
+					cancellationCallbacks = [];
+				}
 				final handle = new CancellationHandle(f, cancellationCallbacks);
 
 				cancellationCallbacks.push(handle);
@@ -168,6 +173,10 @@ abstract class AbstractTask<T> implements ICancellationToken {
 	abstract public function start():Void;
 
 	function cancelChildren(?cause:CancellationException) {
+		if (null == children) {
+			return;
+		}
+
 		for (child in children) {
 			if (child != null) {
 				child.cancel(cause);
@@ -185,6 +194,10 @@ abstract class AbstractTask<T> implements ICancellationToken {
 	}
 
 	function startChildren() {
+		if (null == children) {
+			return;
+		}
+
 		for (child in children) {
 			if (child == null) {
 				continue;
@@ -204,7 +217,7 @@ abstract class AbstractTask<T> implements ICancellationToken {
 				return;
 			case _:
 		}
-		if (numCompletedChildren != children.length) {
+		if (numCompletedChildren != children?.length ?? 0) {
 			return;
 		}
 		switch (state) {
@@ -248,6 +261,10 @@ abstract class AbstractTask<T> implements ICancellationToken {
 	}
 
 	function addChild(child:AbstractTask<Any>) {
+		if (null == children) {
+			children = [];
+		}
+
 		final index = children.push(child);
 		child.indexInParent = index - 1;
 	}

--- a/std/hxcoro/AbstractTask.hx
+++ b/std/hxcoro/AbstractTask.hx
@@ -23,6 +23,7 @@ class TaskException extends Exception {}
 **/
 abstract class AbstractTask<T> {
 	final children:Array<AbstractTask<Any>>;
+	final cancellationCallbacks:Array<()->Void>;
 	var state:TaskState;
 	var error:Null<Exception>;
 	var numCompletedChildren:Int;
@@ -34,6 +35,7 @@ abstract class AbstractTask<T> {
 	public function new() {
 		state = Created;
 		children = [];
+		cancellationCallbacks = [];
 		numCompletedChildren = 0;
 		indexInParent = -1;
 	}
@@ -61,6 +63,11 @@ abstract class AbstractTask<T> {
 					error = cause;
 				}
 				state = Cancelling;
+
+				for (f in cancellationCallbacks) {
+					f();
+				}
+
 				cancelChildren(cause);
 				checkCompletion();
 			case _:
@@ -90,6 +97,15 @@ abstract class AbstractTask<T> {
 				true;
 			case _:
 				false;
+		}
+	}
+
+	public function onCancellationRequested(f:()->Void) {
+		switch state {
+			case Cancelling | Cancelled:
+				f();
+			case _:
+				cancellationCallbacks.push(f);
 		}
 	}
 

--- a/std/hxcoro/AbstractTask.hx
+++ b/std/hxcoro/AbstractTask.hx
@@ -14,6 +14,24 @@ enum abstract TaskState(Int) {
 
 class TaskException extends Exception {}
 
+class CancellationHandle {
+	final func : ()->Void;
+	final all : Array<CancellationHandle>;
+
+	public function new(func, all) {
+		this.func = func;
+		this.all  = all;
+	}
+
+	public function run() {
+		func();
+	}
+
+	public function close() {
+		all.remove(this);
+	}
+}
+
 /**
 	AbstractTask is the base class for tasks which manages its `TaskState` and children.
 
@@ -23,7 +41,7 @@ class TaskException extends Exception {}
 **/
 abstract class AbstractTask<T> {
 	final children:Array<AbstractTask<Any>>;
-	final cancellationCallbacks:Array<()->Void>;
+	final cancellationCallbacks:Array<CancellationHandle>;
 	var state:TaskState;
 	var error:Null<Exception>;
 	var numCompletedChildren:Int;
@@ -64,8 +82,8 @@ abstract class AbstractTask<T> {
 				}
 				state = Cancelling;
 
-				for (f in cancellationCallbacks) {
-					f();
+				for (h in cancellationCallbacks) {
+					h.run();
 				}
 
 				cancelChildren(cause);
@@ -101,11 +119,19 @@ abstract class AbstractTask<T> {
 	}
 
 	public function onCancellationRequested(f:()->Void) {
-		switch state {
+		return switch state {
 			case Cancelling | Cancelled:
 				f();
+
+				// todo have some sort of no op handle again.
+
+				new CancellationHandle(f, cancellationCallbacks);
 			case _:
-				cancellationCallbacks.push(f);
+				final handle = new CancellationHandle(f, cancellationCallbacks);
+
+				cancellationCallbacks.push(handle);
+
+				handle;
 		}
 	}
 

--- a/std/hxcoro/AbstractTask.hx
+++ b/std/hxcoro/AbstractTask.hx
@@ -151,12 +151,10 @@ abstract class AbstractTask<T> implements ICancellationToken {
 
 				return noOpCancellationHandle;
 			case _:
-				if (null == cancellationCallbacks) {
-					cancellationCallbacks = [];
-				}
-				final handle = new CancellationHandle(f, cancellationCallbacks);
+				final container = cancellationCallbacks ??= [];
+				final handle    = new CancellationHandle(f, container);
 
-				cancellationCallbacks.push(handle);
+				container.push(handle);
 
 				handle;
 		}
@@ -261,11 +259,8 @@ abstract class AbstractTask<T> implements ICancellationToken {
 	}
 
 	function addChild(child:AbstractTask<Any>) {
-		if (null == children) {
-			children = [];
-		}
-
-		final index = children.push(child);
+		final container = children ??= [];
+		final index     = container.push(child);
 		child.indexInParent = index - 1;
 	}
 }

--- a/std/hxcoro/Coro.hx
+++ b/std/hxcoro/Coro.hx
@@ -20,8 +20,14 @@ class Coro {
 
 	@:coroutine @:coroutine.nothrow public static function delay(ms:Int):Void {
 		suspend(cont -> {
-			cont.context.get(Scheduler.key).schedule(ms, () -> {
+			final task   = cont.context.get(hxcoro.CoroTask.key);
+			final handle = cont.context.get(Scheduler.key).schedule(ms, () -> {
 				cont.resume(null, cancellationRequested(cont) ? new CancellationException() : null);
+			});
+
+			task.onCancellationRequested(() -> {
+				handle.close();
+				cont.resume(null, new CancellationException());
 			});
 		});
 	}

--- a/std/hxcoro/Coro.hx
+++ b/std/hxcoro/Coro.hx
@@ -4,6 +4,7 @@ import haxe.coro.IContinuation;
 import haxe.coro.SuspensionResult;
 import haxe.coro.schedulers.Scheduler;
 import haxe.coro.schedulers.ISchedulerHandle;
+import haxe.coro.cancellation.CancellationToken;
 import haxe.coro.cancellation.ICancellationHandle;
 import haxe.exceptions.CancellationException;
 
@@ -17,7 +18,7 @@ class Coro {
 	}
 
 	static function cancellationRequested(cont:IContinuation<Any>) {
-		return cont.context.get(hxcoro.CoroTask.key)?.isCancellationRequested;
+		return cont.context.get(CancellationToken.key)?.isCancellationRequested;
 	}
 
 	@:coroutine @:coroutine.nothrow public static function delay(ms:Int):Void {
@@ -25,14 +26,14 @@ class Coro {
 			var scheduleHandle     : ISchedulerHandle = null;
 			var cancellationHandle : ICancellationHandle = null;
 
-			final task = cont.context.get(hxcoro.CoroTask.key);
+			final ct = cont.context.get(CancellationToken.key);
 
 			scheduleHandle = cont.context.get(Scheduler.key).schedule(ms, () -> {
 				cancellationHandle.close();
-				cont.resume(null, task.isCancellationRequested ? new CancellationException() : null);
+				cont.resume(null, ct.isCancellationRequested ? new CancellationException() : null);
 			});
 
-			cancellationHandle = task.onCancellationRequested(() -> {
+			cancellationHandle = ct.onCancellationRequested(() -> {
 				scheduleHandle.close();
 				cont.resume(null, new CancellationException());
 			});

--- a/std/hxcoro/Coro.hx
+++ b/std/hxcoro/Coro.hx
@@ -4,6 +4,7 @@ import haxe.coro.IContinuation;
 import haxe.coro.SuspensionResult;
 import haxe.coro.schedulers.Scheduler;
 import haxe.coro.schedulers.ISchedulerHandle;
+import haxe.coro.cancellation.ICancellationHandle;
 import haxe.exceptions.CancellationException;
 
 class Coro {
@@ -16,19 +17,19 @@ class Coro {
 	}
 
 	static function cancellationRequested(cont:IContinuation<Any>) {
-		return cont.context.get(hxcoro.CoroTask.key)?.cancellationRequested();
+		return cont.context.get(hxcoro.CoroTask.key)?.isCancellationRequested;
 	}
 
 	@:coroutine @:coroutine.nothrow public static function delay(ms:Int):Void {
 		suspend(cont -> {
 			var scheduleHandle     : ISchedulerHandle = null;
-			var cancellationHandle : hxcoro.AbstractTask.CancellationHandle = null;
+			var cancellationHandle : ICancellationHandle = null;
 
 			final task = cont.context.get(hxcoro.CoroTask.key);
 
 			scheduleHandle = cont.context.get(Scheduler.key).schedule(ms, () -> {
 				cancellationHandle.close();
-				cont.resume(null, cancellationRequested(cont) ? new CancellationException() : null);
+				cont.resume(null, task.isCancellationRequested ? new CancellationException() : null);
 			});
 
 			cancellationHandle = task.onCancellationRequested(() -> {

--- a/std/hxcoro/Coro.hx
+++ b/std/hxcoro/Coro.hx
@@ -3,6 +3,7 @@ package hxcoro;
 import haxe.coro.IContinuation;
 import haxe.coro.SuspensionResult;
 import haxe.coro.schedulers.Scheduler;
+import haxe.coro.schedulers.ISchedulerHandle;
 import haxe.exceptions.CancellationException;
 
 class Coro {
@@ -20,13 +21,18 @@ class Coro {
 
 	@:coroutine @:coroutine.nothrow public static function delay(ms:Int):Void {
 		suspend(cont -> {
-			final task   = cont.context.get(hxcoro.CoroTask.key);
-			final handle = cont.context.get(Scheduler.key).schedule(ms, () -> {
+			var scheduleHandle     : ISchedulerHandle = null;
+			var cancellationHandle : hxcoro.AbstractTask.CancellationHandle = null;
+
+			final task = cont.context.get(hxcoro.CoroTask.key);
+
+			scheduleHandle = cont.context.get(Scheduler.key).schedule(ms, () -> {
+				cancellationHandle.close();
 				cont.resume(null, cancellationRequested(cont) ? new CancellationException() : null);
 			});
 
-			task.onCancellationRequested(() -> {
-				handle.close();
+			cancellationHandle = task.onCancellationRequested(() -> {
+				scheduleHandle.close();
 				cont.resume(null, new CancellationException());
 			});
 		});

--- a/std/hxcoro/CoroTask.hx
+++ b/std/hxcoro/CoroTask.hx
@@ -1,14 +1,15 @@
 package hxcoro;
 
-import haxe.exceptions.CancellationException;
-import hxcoro.AbstractTask;
 import hxcoro.ICoroTask;
-import haxe.coro.context.Context;
-import haxe.coro.context.Key;
-import haxe.coro.context.IElement;
-import haxe.coro.IContinuation;
-import haxe.coro.schedulers.Scheduler;
+import hxcoro.AbstractTask;
 import haxe.Exception;
+import haxe.coro.IContinuation;
+import haxe.coro.context.Key;
+import haxe.coro.context.Context;
+import haxe.coro.context.IElement;
+import haxe.coro.schedulers.Scheduler;
+import haxe.coro.cancellation.CancellationToken;
+import haxe.exceptions.CancellationException;
 
 private class CoroTaskWith<T> implements ICoroNode {
 	public var context(get, null):Context;
@@ -67,7 +68,7 @@ abstract class CoroTask<T> extends AbstractTask<T> implements IContinuation<T> i
 	**/
 	public function new(context:Context, lambda:NodeLambda<T>) {
 		super();
-		this.context = context.clone().with(this);
+		this.context = context.clone().with(this).add(CancellationToken.key, this);
 		this.lambda = lambda;
 		awaitingContinuations = [];
 		wasResumed = true;

--- a/tests/misc/coroutines/src/Main.hx
+++ b/tests/misc/coroutines/src/Main.hx
@@ -22,7 +22,8 @@ function main() {
 		new structured.TestChildScopes(),
 		new structured.TestLazyScopes(),
 		new structured.TestThrowingScopes(),
-		new structured.TestCoroutineScope()
+		new structured.TestCoroutineScope(),
+		new structured.TestTaskCancellation()
 	];
 
 	var runner = new utest.Runner();

--- a/tests/misc/coroutines/src/schedulers/TestVirtualTimeScheduler.hx
+++ b/tests/misc/coroutines/src/schedulers/TestVirtualTimeScheduler.hx
@@ -122,4 +122,55 @@ class TestVirtualTimeScheduler extends utest.Test {
 
 		Assert.raises(() -> sut.advanceTo(500), ArgumentException);
 	}
+
+	public function test_cancelling_scheduled_event() {
+		final result = [];
+		final sut    = new VirtualTimeScheduler();
+		final _      = sut.schedule(10, () -> result.push(0));
+		final handle = sut.schedule(20, () -> result.push(1));
+		final _      = sut.schedule(30, () -> result.push(2));
+
+		handle.close();
+
+		sut.advanceTo(30);
+
+		Assert.same([ 0, 2 ], result);
+	}
+
+	public function test_cancelling_head() {
+		final result = [];
+		final sut    = new VirtualTimeScheduler();
+		final handle = sut.schedule(10, () -> result.push(0));
+		final _      = sut.schedule(20, () -> result.push(1));
+
+		handle.close();
+
+		sut.advanceTo(20);
+
+		Assert.same([ 1 ], result);
+	}
+
+	public function test_cancelling_single_head() {
+		final result = [];
+		final sut    = new VirtualTimeScheduler();
+		final handle = sut.schedule(10, () -> result.push(0));
+
+		handle.close();
+
+		sut.advanceTo(10);
+
+		Assert.same([], result);
+	}
+
+	public function test_cancelling_executed_function() {
+		final result = [];
+		final sut    = new VirtualTimeScheduler();
+		final handle = sut.schedule(10, () -> result.push(0));
+
+		sut.advanceTo(10);
+
+		handle.close();
+
+		Assert.same([ 0 ], result);
+	}
 }

--- a/tests/misc/coroutines/src/structured/TestTaskCancellation.hx
+++ b/tests/misc/coroutines/src/structured/TestTaskCancellation.hx
@@ -2,8 +2,8 @@ package structured;
 
 import haxe.Exception;
 import haxe.coro.schedulers.VirtualTimeScheduler;
+import haxe.coro.cancellation.ICancellationHandle;
 import hxcoro.CoroTask;
-import hxcoro.AbstractTask.CancellationHandle;
 
 class TestTaskCancellation extends utest.Test {
 	public function test_cancellation_callback() {
@@ -27,7 +27,7 @@ class TestTaskCancellation extends utest.Test {
 	}
 
 	public function test_closing_cancellation_callback() {
-		var handle : CancellationHandle = null;
+		var handle : ICancellationHandle = null;
 
 		final result    = [];
 		final scheduler = new VirtualTimeScheduler();

--- a/tests/misc/coroutines/src/structured/TestTaskCancellation.hx
+++ b/tests/misc/coroutines/src/structured/TestTaskCancellation.hx
@@ -1,0 +1,57 @@
+package structured;
+
+import haxe.Exception;
+import haxe.coro.schedulers.VirtualTimeScheduler;
+import hxcoro.CoroTask;
+import hxcoro.AbstractTask.CancellationHandle;
+
+class TestTaskCancellation extends utest.Test {
+	public function test_cancellation_callback() {
+		final result    = [];
+		final scheduler = new VirtualTimeScheduler();
+		final task      = CoroRun.with(scheduler).create(node -> {
+			node.context.get(CoroTask.key).onCancellationRequested(() -> {
+				result.push(0);
+			});
+
+			delay(1000);
+		});
+
+		task.start();
+		task.cancel();
+
+		scheduler.advanceBy(1);
+
+		Assert.isFalse(task.isActive());
+		Assert.same([ 0 ], result);
+	}
+
+	public function test_closing_cancellation_callback() {
+		var handle : CancellationHandle = null;
+
+		final result    = [];
+		final scheduler = new VirtualTimeScheduler();
+		final task      = CoroRun.with(scheduler).create(node -> {
+			handle = node.context.get(CoroTask.key).onCancellationRequested(() -> {
+				result.push(0);
+			});
+
+			delay(1000);
+		});
+
+		task.start();
+
+		scheduler.advanceBy(1);
+
+		handle.close();
+
+		scheduler.advanceBy(1);
+
+		task.cancel();
+
+		scheduler.advanceBy(1);
+
+		Assert.isFalse(task.isActive());
+		Assert.same([], result);
+	}
+}

--- a/tests/misc/coroutines/src/structured/TestThrowingScopes.hx
+++ b/tests/misc/coroutines/src/structured/TestThrowingScopes.hx
@@ -110,11 +110,9 @@ class TestThrowingScopes extends utest.Test {
 			child.cancel();
 		});
 
-		// TODO : Once eager cancellation of delay is implemented advance time by 500ms and see if we're active.
-
 		task.start();
 
-		scheduler.advanceBy(1000);
+		scheduler.advanceBy(500);
 
 		Assert.isFalse(task.isActive());
 	}


### PR DESCRIPTION
Closes #105.

There are several parts to this, first the schedulers `schedule` function returns a handle which allows you to stop that function from being executed in the future. If it's currently being executed or has already been it does nothing. This is completely independent and unrelated to the cancellation propagation of structured concurrency.

The second is the `ICancellationToken` interface which `AbstractTask` now implements. This exposes a read only property for if cancellation has been requested and the ability to register a callback which will be registered if / when the task is cancelled. These two things allow delay to now exit immediately when cancellation occurs.

I ultimately went with a cancellation token approach here as now that we're thinking of splitting hxcoro into a haxelib I think there is good value in a basic "universal" cancellation mechanism in the coro std lib. Thinking of something like asys which would assumably be in the std lib, if it were to support cancellation then it could use the cancellation token interfaces to do so. hxcoro would then work with it and if someone else makes a coroutine framework all they need to do is also support that basic interface. Hopefully it's slim enough to be unobtrusive to implement but also actually useful (polling and callback seems like it will cover all bases).

There are still a few things I want to do / decide on.

- It would be nice if there was a cancellation token key for the context, even if it ultimately returns the same task object. But I don't think that possible with our current approach.
- I wrote some (hopefully useful) comments on some of the interfaces, I want to do the same for cancellation token as well and will try and do similar going forward so save the pain of having to do it all at the end.
- I'm being quite eager in allocating the empty arrays for tasks which will hold the handles. This could probably be done lazilly to stop allocations if the api is not used.