### PR TITLE
Untie lambdas from CoroTask

### DIFF
--- a/std/hxcoro/AbstractTask.hx
+++ b/std/hxcoro/AbstractTask.hx
@@ -101,7 +101,15 @@ abstract class AbstractTask<T> {
 	/**
 		Starts executing this task. Has no effect if the task is already active or has completed.
 	**/
-	abstract public function start():Void;
+	public function start() {
+		switch (state) {
+			case Created:
+				state = Running;
+				doStart();
+			case _:
+				return;
+		}
+	}
 
 	function cancelChildren(?cause:CancellationException) {
 		for (child in children) {
@@ -114,10 +122,6 @@ abstract class AbstractTask<T> {
 	final inline function beginCompleting() {
 		state = Completing;
 		startChildren();
-	}
-
-	final inline function beginRunning() {
-		state = Running;
 	}
 
 	function startChildren() {
@@ -153,6 +157,8 @@ abstract class AbstractTask<T> {
 		}
 		complete();
 	}
+
+	abstract function doStart():Void;
 
 	abstract function complete():Void;
 

--- a/std/hxcoro/Coro.hx
+++ b/std/hxcoro/Coro.hx
@@ -37,7 +37,8 @@ class Coro {
 	@:coroutine static public function scope<T>(lambda:NodeLambda<T>):T {
 		return suspend(cont -> {
 			final context = cont.context;
-			final scope = new CoroScopeTask(context, lambda);
+			final scope = new CoroScopeTask(context);
+			scope.runNodeLambda(lambda);
 			scope.awaitContinuation(cont);
 		});
 	}

--- a/std/hxcoro/CoroChildTask.hx
+++ b/std/hxcoro/CoroChildTask.hx
@@ -3,12 +3,13 @@ package hxcoro;
 import haxe.coro.context.Context;
 import haxe.Exception;
 import haxe.exceptions.CancellationException;
+import hxcoro.ICoroTask;
 
 class CoroChildTask<T> extends CoroTask<T> {
 	final parent:AbstractTask<Any>;
 
-	public function new(context:Context, lambda:NodeLambda<T>, parent:AbstractTask<Any>) {
-		super(context, lambda);
+	public function new(context:Context, parent:AbstractTask<Any>) {
+		super(context);
 		this.parent = parent;
 		parent.addChild(this);
 	}
@@ -40,5 +41,25 @@ class CoroChildTask<T> extends CoroTask<T> {
 	function complete() {
 		parent?.childCompletes(this, true);
 		handleAwaitingContinuations();
+	}
+}
+
+class StartableCoroChildTask<T> extends CoroChildTask<T> implements IStartableCoroTask<T> {
+	final lambda:NodeLambda<T>;
+
+	/**
+		Creates a new task using the provided `context` in order to execute `lambda`.
+	**/
+	public function new(context:Context, lambda:NodeLambda<T>, parent:AbstractTask<Any>) {
+		super(context, parent);
+		this.lambda = lambda;
+	}
+
+	/**
+		Starts executing this task's `lambda`. Has no effect if the task is already active or has completed.
+	**/
+	override public function doStart() {
+		super.doStart();
+		runNodeLambda(lambda);
 	}
 }

--- a/std/hxcoro/CoroRun.hx
+++ b/std/hxcoro/CoroRun.hx
@@ -12,7 +12,7 @@ private abstract RunnableContext(ElementTree) {
 	}
 
 	public function create<T>(lambda:NodeLambda<T>):IStartableCoroTask<T> {
-		return new CoroScopeTask(new Context(this), lambda);
+		return new CoroScopeTask.StartableCoroScopeTask(new Context(this), lambda);
 	}
 
 	public function run<T>(lambda:NodeLambda<T>):T {
@@ -54,8 +54,8 @@ class CoroRun {
 
 	static public function runWith<T>(context:Context, lambda:NodeLambda<T>):T {
 		final schedulerComponent = new EventLoopScheduler();
-		final scope = new CoroScopeTask(context.clone().with(schedulerComponent), lambda);
-		scope.start();
+		final scope = new CoroScopeTask(context.clone().with(schedulerComponent));
+		scope.runNodeLambda(lambda);
 		while (scope.isActive()) {
 			schedulerComponent.run();
 		}

--- a/std/hxcoro/CoroScopeTask.hx
+++ b/std/hxcoro/CoroScopeTask.hx
@@ -3,12 +3,13 @@ package hxcoro;
 import haxe.Exception;
 import haxe.exceptions.CancellationException;
 import haxe.coro.context.Context;
+import hxcoro.ICoroTask;
 
 class CoroScopeTask<T> extends CoroTask<T> {
 	final parent:Null<AbstractTask<Any>>;
 
-	public function new(context:Context, lambda:NodeLambda<T>) {
-		super(context, lambda);
+	public function new(context:Context) {
+		super(context);
 		// slightly subtle: context here refers to the incoming context which still holds the parent
 		parent = context.get(hxcoro.CoroTask.key);
 		if (parent != null) {
@@ -30,5 +31,25 @@ class CoroScopeTask<T> extends CoroTask<T> {
 	function complete() {
 		parent?.childCompletes(this, false);
 		handleAwaitingContinuations();
+	}
+}
+
+class StartableCoroScopeTask<T> extends CoroScopeTask<T> implements IStartableCoroTask<T> {
+	final lambda:NodeLambda<T>;
+
+	/**
+		Creates a new task using the provided `context` in order to execute `lambda`.
+	**/
+	public function new(context:Context, lambda:NodeLambda<T>) {
+		super(context);
+		this.lambda = lambda;
+	}
+
+	/**
+		Starts executing this task's `lambda`. Has no effect if the task is already active or has completed.
+	**/
+	override function doStart() {
+		super.doStart();
+		runNodeLambda(lambda);
 	}
 }

--- a/std/hxcoro/CoroTask.hx
+++ b/std/hxcoro/CoroTask.hx
@@ -24,16 +24,16 @@ private class CoroTaskWith<T> implements ICoroNode {
 		return context;
 	}
 
-	public function async<T>(lambda:NodeLambda<T>) {
-		final child = lazy(lambda);
+	public function async<T>(lambda:NodeLambda<T>):ICoroTask<T> {
+		final child = new CoroChildTask(context, task);
 		context.get(Scheduler.key).schedule(0, () -> {
-			child.start();
+			child.runNodeLambda(lambda);
 		});
 		return child;
 	}
 
-	public function lazy<T>(lambda:NodeLambda<T>) {
-		return new CoroChildTask(context, lambda, task);
+	public function lazy<T>(lambda:NodeLambda<T>):IStartableCoroTask<T> {
+		return new CoroChildTask.StartableCoroChildTask(context, lambda, task);
 	}
 
 	public function cancel(?cause:CancellationException) {
@@ -48,8 +48,7 @@ private class CoroTaskWith<T> implements ICoroNode {
 /**
 	CoroTask provides the basic functionality for coroutine tasks.
 **/
-abstract class CoroTask<T> extends AbstractTask<T> implements IContinuation<T> implements ICoroNode implements IStartableCoroTask<T>
-		implements IElement<CoroTask<Any>> {
+abstract class CoroTask<T> extends AbstractTask<T> implements IContinuation<T> implements ICoroNode implements ICoroTask<T> implements IElement<CoroTask<Any>> {
 	public static final key:Key<CoroTask<Any>> = Key.createNew('Task');
 
 	/**
@@ -57,18 +56,16 @@ abstract class CoroTask<T> extends AbstractTask<T> implements IContinuation<T> i
 	**/
 	public var context(get, null):Context;
 
-	final lambda:NodeLambda<T>;
 	var result:Null<T>;
 	var awaitingContinuations:Array<IContinuation<T>>;
 	var wasResumed:Bool;
 
 	/**
-		Creates a new task using the provided `context` in order to execute `lambda`.
+		Creates a new task using the provided `context`.
 	**/
-	public function new(context:Context, lambda:NodeLambda<T>) {
+	public function new(context:Context) {
 		super();
 		this.context = context.clone().with(this);
-		this.lambda = lambda;
 		awaitingContinuations = [];
 		wasResumed = true;
 	}
@@ -85,18 +82,13 @@ abstract class CoroTask<T> extends AbstractTask<T> implements IContinuation<T> i
 		return key;
 	}
 
-	/**
-		Starts executing this task's `lambda`. Has no effect if the task is already active or has completed.
-	**/
-	public function start() {
-		switch (state) {
-			case Created:
-				beginRunning();
-				wasResumed = false;
-			case _:
-				return;
-		}
+	public function doStart() {
+		wasResumed = false;
+	}
+
+	public function runNodeLambda(lambda:NodeLambda<T>) {
 		final result = lambda(this, this);
+		start();
 		switch result.state {
 			case Pending:
 				return;
@@ -112,16 +104,16 @@ abstract class CoroTask<T> extends AbstractTask<T> implements IContinuation<T> i
 		method is called. This occurrs automatically once this task has finished execution.
 	**/
 	public function lazy<T>(lambda:NodeLambda<T>):IStartableCoroTask<T> {
-		return new CoroChildTask(context, lambda, this);
+		return new CoroChildTask.StartableCoroChildTask(context, lambda, this);
 	}
 
 	/**
 		Creates a child task to execute `lambda` and starts it automatically.
 	**/
 	public function async<T>(lambda:NodeLambda<T>):ICoroTask<T> {
-		final child = lazy(lambda);
+		final child = new CoroChildTask<T>(context, this);
 		context.get(Scheduler.key).schedule(0, () -> {
-			child.start();
+			child.runNodeLambda(lambda);
 		});
 		return child;
 	}


### PR DESCRIPTION
Removes the `lambda` field from `CoroTask` so that we can use it in other ways. This change makes everything even more OOP which always worries me, but I hope it makes sense still:

```
AbstractTask
    CoroTask
        CoroChildTask
            StartableCoroChildTask
        CoroScopeTask
            StartableCoroScopeTask
```

With this we can use `CoroTask` and its children in other ways, like in this silly example:

```haxe
import haxe.coro.context.Context;
import hxcoro.CoroTask;
import hxcoro.AbstractTask;
import hxcoro.ICoroNode;
import hxcoro.CoroChildTask;
import hxcoro.CoroRun;
import hxcoro.Coro.*;
import haxe.Exception;

using Main.FunctionTask;

class FunctionTask<A, T> extends CoroChildTask<T> {
	final arg:A;
	final f:A->T;

	public function new(context:Context, arg:A, f:A->T, parent:AbstractTask<Any>) {
		super(context, parent);
		this.arg = arg;
		this.f = f;
	}

	override function doStart() {
		super.doStart();
		try {
			resume(f(arg), null);
		} catch (e:Exception) {
			resume(null, e);
		}
	}

	static public function fun<A, T>(node:ICoroNode, arg:A, f:A->T) {
		return new FunctionTask(node.context, arg, f, node.context.get(CoroTask.key));
	}

	@:coroutine static public function execute<A, T>(f:A->T, arg:A) {
		return suspend(cont -> {
			final context = cont.context;
			final parent = context.get(hxcoro.CoroTask.key);
			final task = fun(parent, arg, f);
			task.start();
			task.awaitContinuation(cont);
		});
	}
}

function main() {
	function double(i:Int) {
		return i * 2;
	}

	CoroRun.runScoped(node -> {
		final child = node.fun(12, double);
		trace(child.await()); // 24

		// this was supposed to be a static extension double.execute(13), but that doesn't work yet
		trace(FunctionTask.execute(double, 13)); // 26

		node.fun("failure", arg -> throw arg); // throws failure
	});
}
```

Closes #115