### PR TITLE
Don't reschedule BaseContinuation.resume

### DIFF
--- a/std/haxe/coro/BaseContinuation.hx
+++ b/std/haxe/coro/BaseContinuation.hx
@@ -54,14 +54,17 @@ abstract class BaseContinuation<T> extends SuspensionResult<T> implements IConti
 		recursing = false;
 
 		final result = invokeResume();
-		switch (result.state) {
-			case Pending:
-				return;
-			case Returned:
-				completion.resume(result.result, null);
-			case Thrown:
-				completion.resume(null, result.error);
-		}
+		final completion = completion; // avoid capturing `this` in the closure
+		context.get(Scheduler.key).schedule(0, () -> {
+			switch (result.state) {
+				case Pending:
+					return;
+				case Returned:
+					completion.resume(result.result, null);
+				case Thrown:
+					completion.resume(null, result.error);
+			}
+		});
     }
 
     public function callerFrame():Null<IStackFrame> {

--- a/std/haxe/coro/BaseContinuation.hx
+++ b/std/haxe/coro/BaseContinuation.hx
@@ -51,19 +51,17 @@ abstract class BaseContinuation<T> extends SuspensionResult<T> implements IConti
     public final function resume(result:Any, error:Exception):Void {
         this.result = result;
         this.error  = error;
-        context.get(Scheduler.key).schedule(0, () -> {
-			recursing = false;
+		recursing = false;
 
-			final result = invokeResume();
-			switch (result.state) {
-				case Pending:
-					return;
-				case Returned:
-					completion.resume(result.result, null);
-				case Thrown:
-					completion.resume(null, result.error);
-			}
-        });
+		final result = invokeResume();
+		switch (result.state) {
+			case Pending:
+				return;
+			case Returned:
+				completion.resume(result.result, null);
+			case Thrown:
+				completion.resume(null, result.error);
+		}
     }
 
     public function callerFrame():Null<IStackFrame> {


### PR DESCRIPTION
Do you happen to remember why it is like this? The tests pass without it and this avoids allocating a closure and scheduler object on every resume.