### PR TITLE
Don't have RacingContinuation hold onto its mutex for so long

### DIFF
--- a/std/haxe/coro/continuations/RacingContinuation.hx
+++ b/std/haxe/coro/continuations/RacingContinuation.hx
@@ -49,22 +49,25 @@ class RacingContinuation<T> extends SuspensionResult<T> implements IContinuation
 
 
 	public function resolve():Void {
-		inline function updateState() {
+		// same logic as resume
+		final mutex = mutex;
+		if (mutex == null) {
 			if (error != null) {
 				state = Thrown;
 			} else {
 				state = Returned;
 			}
-		}
-		// same logic as resume
-		final mutex = mutex;
-		if (mutex == null) {
-			return updateState();
+			return;
 		}
 		mutex.acquire();
 		if (this.mutex == null) {
 			mutex.release();
-			return updateState();
+			if (error != null) {
+				state = Thrown;
+			} else {
+				state = Returned;
+			}
+			return;
 		}
 		this.mutex = null;
 		mutex.release();

--- a/std/haxe/coro/continuations/RacingContinuation.hx
+++ b/std/haxe/coro/continuations/RacingContinuation.hx
@@ -6,19 +6,14 @@ import haxe.coro.schedulers.Scheduler;
 class RacingContinuation<T> extends SuspensionResult<T> implements IContinuation<T> {
 	final inputCont:IContinuation<T>;
 
-	var lock:Mutex;
-
-	var resumed:Bool;
-	var resolved:Bool;
+	var mutex:Null<Mutex>;
 
 	public var context(get, null):Context;
 
 	public function new(inputCont:IContinuation<T>) {
 		this.inputCont = inputCont;
 		context = inputCont.context;
-		resumed = false;
-		resolved = false;
-		lock = new Mutex();
+		mutex = new Mutex();
 	}
 
 	inline function get_context() {
@@ -26,38 +21,53 @@ class RacingContinuation<T> extends SuspensionResult<T> implements IContinuation
 	}
 
 	public function resume(result:T, error:Exception):Void {
-		lock.acquire();
-		if (resolved) {
-			// if we already have a value, schedule the follow-up resume call with that value
-			final inputCont = inputCont;
+		inline function resumeContinue(result:T, error:Exception) {
 			context.get(Scheduler.key).schedule(0, () -> {
 				inputCont.resume(result, error);
 			});
-			lock.release();
-			lock = null;
-		} else {
-			// otherwise we can assign immediately
-			resumed = true;
-			this.result = result;
-			this.error = error;
-			lock.release();
 		}
+
+		// Store mutex as stack value.
+		final mutex = mutex;
+		if (mutex == null) {
+			// If that's already null we're definitely done.
+			return resumeContinue(result, error);
+		}
+		// Otherwise we take the mutex now. We know that the stack value isn't null, so that's safe.
+		mutex.acquire();
+		if (this.mutex == null) {
+			// The shared reference has become null in the meantime, so we're done.
+			mutex.release();
+			return resumeContinue(result, error);
+		}
+		// At this point we own the mutex, so we're first. We can set the shared reference to null and release it.
+		this.mutex = null;
+		mutex.release();
+		this.result = result;
+		this.error = error;
 	}
 
+
 	public function resolve():Void {
-		lock.acquire();
-		if (resumed) {
+		inline function updateState() {
 			if (error != null) {
 				state = Thrown;
 			} else {
 				state = Returned;
 			}
-			lock.release();
-			lock = null;
-		} else {
-			resolved = true;
-			state = Pending;
-			lock.release();
 		}
+		// same logic as resume
+		final mutex = mutex;
+		if (mutex == null) {
+			return updateState();
+		}
+		mutex.acquire();
+		if (this.mutex == null) {
+			mutex.release();
+			return updateState();
+		}
+		this.mutex = null;
+		mutex.release();
+		state = Pending;
 	}
 }

--- a/std/haxe/coro/continuations/RacingContinuation.hx
+++ b/std/haxe/coro/continuations/RacingContinuation.hx
@@ -21,6 +21,8 @@ class RacingContinuation<T> extends SuspensionResult<T> implements IContinuation
 	}
 
 	public function resume(result:T, error:Exception):Void {
+		// store in a local to avoid `this` capturing.
+		final inputCont = inputCont;
 		inline function resumeContinue(result:T, error:Exception) {
 			context.get(Scheduler.key).schedule(0, () -> {
 				inputCont.resume(result, error);

--- a/std/haxe/coro/continuations/RacingContinuation.hx
+++ b/std/haxe/coro/continuations/RacingContinuation.hx
@@ -3,19 +3,21 @@ package haxe.coro.continuations;
 import haxe.coro.context.Context;
 import haxe.coro.schedulers.Scheduler;
 
-@:coreApi class RacingContinuation<T> extends SuspensionResult<T> implements IContinuation<T> {
+class RacingContinuation<T> extends SuspensionResult<T> implements IContinuation<T> {
 	final inputCont:IContinuation<T>;
 
-	final lock:Mutex;
+	var lock:Mutex;
 
-	var assigned:Bool;
+	var resumed:Bool;
+	var resolved:Bool;
 
 	public var context(get, null):Context;
 
 	public function new(inputCont:IContinuation<T>) {
 		this.inputCont = inputCont;
 		context = inputCont.context;
-		assigned = false;
+		resumed = false;
+		resolved = false;
 		lock = new Mutex();
 	}
 
@@ -24,34 +26,36 @@ import haxe.coro.schedulers.Scheduler;
 	}
 
 	public function resume(result:T, error:Exception):Void {
-		context.get(Scheduler.key).schedule(0, () -> {
-			lock.acquire();
-
-			if (assigned) {
-				lock.release();
+		lock.acquire();
+		if (resolved) {
+			// if we already have a value, schedule the follow-up resume call with that value
+			final inputCont = inputCont;
+			context.get(Scheduler.key).schedule(0, () -> {
 				inputCont.resume(result, error);
-			} else {
-				assigned = true;
-				this.result = result;
-				this.error = error;
-
-				lock.release();
-			}
-		});
+			});
+			lock.release();
+			lock = null;
+		} else {
+			// otherwise we can assign immediately
+			resumed = true;
+			this.result = result;
+			this.error = error;
+			lock.release();
+		}
 	}
 
 	public function resolve():Void {
 		lock.acquire();
-		if (assigned) {
+		if (resumed) {
 			if (error != null) {
 				state = Thrown;
-				lock.release();
 			} else {
 				state = Returned;
-				lock.release();
 			}
+			lock.release();
+			lock = null;
 		} else {
-			assigned = true;
+			resolved = true;
 			state = Pending;
 			lock.release();
 		}


### PR DESCRIPTION
I've split up `assigned` into `resumed` and `resolved`, and unset the mutex once both of them are true because at that point we won't need it anymore. This helps a little but I think we still hold onto the mutex for way too long. There should be a way to free the resource at the end of `resolve`, because at that point we can only come across `resume`. And that can happen way later because continuations can be stored.