### PR TITLE
Work with ICancellationHandle instead of its closure

### DIFF
--- a/std/haxe/coro/cancellation/CancellationToken.hx
+++ b/std/haxe/coro/cancellation/CancellationToken.hx
@@ -14,7 +14,7 @@ private class NoOpCancellationToken implements ICancellationToken {
 
 	public function new() {}
 
-	public function onCancellationRequested(func:() -> Void):ICancellationHandle {
+	public function onCancellationRequested(_:ICancellationHandle):ICancellationHandle {
 		return handle;
 	}
 	public function get_isCancellationRequested() {

--- a/std/haxe/coro/cancellation/CancellationToken.hx
+++ b/std/haxe/coro/cancellation/CancellationToken.hx
@@ -14,7 +14,7 @@ private class NoOpCancellationToken implements ICancellationToken {
 
 	public function new() {}
 
-	public function onCancellationRequested(_:ICancellationHandle):ICancellationHandle {
+	public function onCancellationRequested(_:ICancellationCallback):ICancellationHandle {
 		return handle;
 	}
 	public function get_isCancellationRequested() {

--- a/std/haxe/coro/cancellation/ICancellationCallback.hx
+++ b/std/haxe/coro/cancellation/ICancellationCallback.hx
@@ -1,0 +1,5 @@
+package haxe.coro.cancellation;
+
+interface ICancellationCallback {
+	function onCancellation():Void;
+}

--- a/std/haxe/coro/cancellation/ICancellationToken.hx
+++ b/std/haxe/coro/cancellation/ICancellationToken.hx
@@ -17,5 +17,5 @@ interface ICancellationToken {
 	 * @param func Callback to be executed when the token is cancelled.
 	 * @return Cancellation handle which can be used to cancel the callback from executing.
 	 */
-	function onCancellationRequested(handle : ICancellationHandle) : ICancellationHandle;
+	function onCancellationRequested(handle : ICancellationCallback) : ICancellationHandle;
 }

--- a/std/haxe/coro/cancellation/ICancellationToken.hx
+++ b/std/haxe/coro/cancellation/ICancellationToken.hx
@@ -11,11 +11,11 @@ interface ICancellationToken {
 
 	/**
 	 * Register a callback which will be executed when this token is cancelled.
-	 * 
+	 *
 	 * If this token has already been cancelled the function will be executed immediately and synchronously, any exception raised will not be caught.
 	 * The thread the callback is executed on is implementation defined if cancellation has not been yet been requested.
 	 * @param func Callback to be executed when the token is cancelled.
 	 * @return Cancellation handle which can be used to cancel the callback from executing.
 	 */
-	function onCancellationRequested(func : ()->Void) : ICancellationHandle;
+	function onCancellationRequested(handle : ICancellationHandle) : ICancellationHandle;
 }

--- a/std/hxcoro/continuations/CancellingContinuation.hx
+++ b/std/hxcoro/continuations/CancellingContinuation.hx
@@ -9,7 +9,7 @@ import haxe.coro.schedulers.Scheduler;
 import haxe.coro.cancellation.ICancellationHandle;
 import haxe.coro.cancellation.CancellationToken;
 
-class CancellingContinuation<T> implements ICancellingContinuation<T> {
+class CancellingContinuation<T> implements ICancellingContinuation<T> implements ICancellationHandle {
 	final cont : IContinuation<T>;
 
 	final handle : ICancellationHandle;
@@ -32,7 +32,7 @@ class CancellingContinuation<T> implements ICancellingContinuation<T> {
 
 	public function new(cont) {
 		this.cont   = cont;
-		this.handle = this.cont.context.get(CancellationToken.key).onCancellationRequested(doCancellation);
+		this.handle = this.cont.context.get(CancellationToken.key).onCancellationRequested(this);
 	}
 
 	public function resume(result:T, error:Exception) {
@@ -50,7 +50,7 @@ class CancellingContinuation<T> implements ICancellingContinuation<T> {
 
 	}
 
-	function doCancellation() {
+	public function close() {
 		if (null != onCancellationRequested) {
 			onCancellationRequested();
 		}

--- a/std/hxcoro/continuations/CancellingContinuation.hx
+++ b/std/hxcoro/continuations/CancellingContinuation.hx
@@ -8,8 +8,9 @@ import haxe.coro.context.Context;
 import haxe.coro.schedulers.Scheduler;
 import haxe.coro.cancellation.ICancellationHandle;
 import haxe.coro.cancellation.CancellationToken;
+import haxe.coro.cancellation.ICancellationCallback;
 
-class CancellingContinuation<T> implements ICancellingContinuation<T> implements ICancellationHandle {
+class CancellingContinuation<T> implements ICancellingContinuation<T> implements ICancellationCallback {
 	final cont : IContinuation<T>;
 
 	final handle : ICancellationHandle;
@@ -50,7 +51,7 @@ class CancellingContinuation<T> implements ICancellingContinuation<T> implements
 
 	}
 
-	public function close() {
+	public function onCancellation() {
 		if (null != onCancellationRequested) {
 			onCancellationRequested();
 		}

--- a/std/hxcoro/task/AbstractTask.hx
+++ b/std/hxcoro/task/AbstractTask.hx
@@ -17,13 +17,13 @@ enum abstract TaskState(Int) {
 private class TaskException extends Exception {}
 
 private class CancellationHandle implements ICancellationHandle {
-	final func:() -> Void;
+	final handle:ICancellationHandle;
 	final all:Array<CancellationHandle>;
 
 	var closed:Bool;
 
-	public function new(func, all) {
-		this.func = func;
+	public function new(handle, all) {
+		this.handle = handle;
 		this.all = all;
 
 		closed = false;
@@ -34,7 +34,7 @@ private class CancellationHandle implements ICancellationHandle {
 			return;
 		}
 
-		func();
+		handle.close();
 
 		closed = true;
 	}
@@ -67,7 +67,7 @@ abstract class AbstractTask<T> implements ICancellationToken {
 	static final noOpCancellationHandle = new NoOpCancellationHandle();
 
 	var children:Null<Array<AbstractTask<Any>>>;
-	var cancellationCallbacks:Null<Array<CancellationHandle>>;
+	var cancellationHandles:Null<Array<CancellationHandle>>;
 	var state:TaskState;
 	var error:Null<Exception>;
 	var numCompletedChildren:Int;
@@ -91,7 +91,7 @@ abstract class AbstractTask<T> implements ICancellationToken {
 	public function new() {
 		state = Created;
 		children = null;
-		cancellationCallbacks = null;
+		cancellationHandles = null;
 		numCompletedChildren = 0;
 		indexInParent = -1;
 		allChildrenCompleted = false;
@@ -121,8 +121,8 @@ abstract class AbstractTask<T> implements ICancellationToken {
 				}
 				state = Cancelling;
 
-				if (null != cancellationCallbacks) {
-					for (h in cancellationCallbacks) {
+				if (null != cancellationHandles) {
+					for (h in cancellationHandles) {
 						h.run();
 					}
 				}
@@ -147,15 +147,15 @@ abstract class AbstractTask<T> implements ICancellationToken {
 		}
 	}
 
-	public function onCancellationRequested(f:() -> Void):ICancellationHandle {
+	public function onCancellationRequested(handle:ICancellationHandle):ICancellationHandle {
 		return switch state {
 			case Cancelling | Cancelled:
-				f();
+				handle.close();
 
 				return noOpCancellationHandle;
 			case _:
-				final container = cancellationCallbacks ??= [];
-				final handle = new CancellationHandle(f, container);
+				final container = cancellationHandles ??= [];
+				final handle = new CancellationHandle(handle, container);
 
 				container.push(handle);
 

--- a/std/hxcoro/task/AbstractTask.hx
+++ b/std/hxcoro/task/AbstractTask.hx
@@ -2,6 +2,7 @@ package hxcoro.task;
 
 import haxe.coro.cancellation.ICancellationToken;
 import haxe.coro.cancellation.ICancellationHandle;
+import haxe.coro.cancellation.ICancellationCallback;
 import haxe.exceptions.CancellationException;
 import haxe.Exception;
 
@@ -17,13 +18,13 @@ enum abstract TaskState(Int) {
 private class TaskException extends Exception {}
 
 private class CancellationHandle implements ICancellationHandle {
-	final handle:ICancellationHandle;
+	final callback:ICancellationCallback;
 	final all:Array<CancellationHandle>;
 
 	var closed:Bool;
 
-	public function new(handle, all) {
-		this.handle = handle;
+	public function new(callback, all) {
+		this.callback = callback;
 		this.all = all;
 
 		closed = false;
@@ -34,7 +35,7 @@ private class CancellationHandle implements ICancellationHandle {
 			return;
 		}
 
-		handle.close();
+		callback.onCancellation();
 
 		closed = true;
 	}
@@ -147,10 +148,10 @@ abstract class AbstractTask<T> implements ICancellationToken {
 		}
 	}
 
-	public function onCancellationRequested(handle:ICancellationHandle):ICancellationHandle {
+	public function onCancellationRequested(handle:ICancellationCallback):ICancellationHandle {
 		return switch state {
 			case Cancelling | Cancelled:
-				handle.close();
+				handle.onCancellation();
 
 				return noOpCancellationHandle;
 			case _:

--- a/tests/misc/coroutines/src/structured/TestTaskCancellation.hx
+++ b/tests/misc/coroutines/src/structured/TestTaskCancellation.hx
@@ -1,18 +1,18 @@
 package structured;
 
-import haxe.Exception;
 import haxe.coro.schedulers.VirtualTimeScheduler;
 import haxe.coro.cancellation.ICancellationHandle;
+import haxe.coro.cancellation.ICancellationCallback;
 import hxcoro.task.CoroTask;
 
-class ResultPusherHandle implements ICancellationHandle {
+class ResultPusherHandle implements ICancellationCallback {
 	final result:Array<Int>;
 
 	public function new(result:Array<Int>) {
 		this.result = result;
 	}
 
-	public function close() {
+	public function onCancellation() {
 		result.push(0);
 	}
 }

--- a/tests/misc/coroutines/src/structured/TestTaskCancellation.hx
+++ b/tests/misc/coroutines/src/structured/TestTaskCancellation.hx
@@ -5,14 +5,24 @@ import haxe.coro.schedulers.VirtualTimeScheduler;
 import haxe.coro.cancellation.ICancellationHandle;
 import hxcoro.task.CoroTask;
 
+class ResultPusherHandle implements ICancellationHandle {
+	final result:Array<Int>;
+
+	public function new(result:Array<Int>) {
+		this.result = result;
+	}
+
+	public function close() {
+		result.push(0);
+	}
+}
+
 class TestTaskCancellation extends utest.Test {
 	public function test_cancellation_callback() {
 		final result    = [];
 		final scheduler = new VirtualTimeScheduler();
 		final task      = CoroRun.with(scheduler).create(node -> {
-			node.context.get(CoroTask.key).onCancellationRequested(() -> {
-				result.push(0);
-			});
+			node.context.get(CoroTask.key).onCancellationRequested(new ResultPusherHandle(result));
 
 			delay(1000);
 		});
@@ -32,9 +42,7 @@ class TestTaskCancellation extends utest.Test {
 		final result    = [];
 		final scheduler = new VirtualTimeScheduler();
 		final task      = CoroRun.with(scheduler).create(node -> {
-			handle = node.context.get(CoroTask.key).onCancellationRequested(() -> {
-				result.push(0);
-			});
+			handle = node.context.get(CoroTask.key).onCancellationRequested(new ResultPusherHandle(result));
 
 			delay(1000);
 		});


### PR DESCRIPTION
(Sorry for hijacking all your PRs, but they keep giving me ideas for further improvements!)

With `CancellingContinuation` we now have pretty much exactly what I was thinking about during my `ICloseable` musings. Instead of passing a closure to `onCancellationRequested`, we pass an `ICancellationHandle` and store that. This at least pushes the closure-ness outward so that we can look into working with less closures in the future.