### PR TITLE
Add hxcoro.util.Convenience

### DIFF
--- a/std/hxcoro/Coro.hx
+++ b/std/hxcoro/Coro.hx
@@ -39,7 +39,7 @@ class Coro {
 	@:coroutine @:coroutine.nothrow public static function delay(ms:Int):Void {
 		suspendCancellable(cont -> {
 			final handle = cont.context.get(Scheduler.key).schedule(ms, () -> {
-				cont.resume(null, null);
+				cont.callSync();
 			});
 
 			cont.onCancellationRequested = () -> {
@@ -51,7 +51,7 @@ class Coro {
 	@:coroutine @:coroutine.nothrow public static function yield():Void {
 		suspend(cont -> {
 			cont.context.get(Scheduler.key).schedule(0, () -> {
-				cont.resume(null, cancellationRequested(cont) ? new CancellationException() : null);
+				cont.failSync(cancellationRequested(cont) ? new CancellationException() : null);
 			});
 		});
 	}
@@ -91,12 +91,12 @@ class Coro {
 	@:coroutine public static function timeout<T>(ms:Int, lambda:NodeLambda<T>):T {
 		return suspend(cont -> {
 			if (ms < 0) {
-				cont.resume(null, new ArgumentException('timeout must be positive'));
+				cont.failSync(new ArgumentException('timeout must be positive'));
 
 				return;
 			}
 			if (ms == 0) {
-				cont.resume(null, new TimeoutException());
+				cont.failSync(new TimeoutException());
 
 				return;
 			}

--- a/std/hxcoro/concurrent/CoroSemaphore.hx
+++ b/std/hxcoro/concurrent/CoroSemaphore.hx
@@ -1,13 +1,9 @@
 package hxcoro.concurrent;
 
-import haxe.coro.cancellation.ICancellationCallback;
 import haxe.coro.Mutex;
-import hxcoro.Coro.*;
 import hxcoro.task.CoroTask;
 import hxcoro.ds.PagedDeque;
 import haxe.coro.IContinuation;
-import haxe.coro.cancellation.ICancellationHandle;
-import haxe.exceptions.CancellationException;
 import haxe.coro.cancellation.CancellationToken;
 
 class CoroSemaphore {
@@ -71,7 +67,7 @@ class CoroSemaphore {
 			} else {
 				// continue normally
 				dequeMutex.release();
-				cont.resume(null, null);
+				cont.callAsync();
 				return;
 			}
 		}

--- a/std/hxcoro/continuations/CancellingContinuation.hx
+++ b/std/hxcoro/continuations/CancellingContinuation.hx
@@ -59,7 +59,7 @@ class CancellingContinuation<T> implements ICancellableContinuation<T> implement
 				handle.close();
 				cont.resume(result, error);
 			} else {
-				cont.resume(null, new CancellationException());
+				cont.failAsync(new CancellationException());
 			}
 		});
 	}

--- a/std/hxcoro/continuations/TimeoutContinuation.hx
+++ b/std/hxcoro/continuations/TimeoutContinuation.hx
@@ -23,6 +23,6 @@ class TimeoutContinuation<T> implements IContinuation<T> {
 	public function resume(value:T, error:Exception) {
 		handle.close();
 
-		cont.resume(value, error);
+		cont.resumeAsync(value, error);
 	}
 }

--- a/std/hxcoro/ds/Channel.hx
+++ b/std/hxcoro/ds/Channel.hx
@@ -35,7 +35,7 @@ private class SuspendedWrite<T> implements IContinuation<T> {
 
 	public function resume(v:T, error:Exception) {
 		if (context.get(CancellationToken.key).isCancellationRequested) {
-			continuation.resume(null, new CancellationException());
+			continuation.failAsync(new CancellationException());
 		} else {
 			continuation.resume(v, error);
 		}
@@ -47,7 +47,7 @@ private class SuspendedWrite<T> implements IContinuation<T> {
 			hostPage.data[hostIndex] = null;
 		}
 		// writeMutex.release();
-		resume(null, null);
+		this.callSync();
 	}
 }
 
@@ -75,7 +75,7 @@ class SuspendedRead<T> implements IContinuation<T> {
 
 	public function resume(v:T, error:Exception) {
 		if (context.get(CancellationToken.key).isCancellationRequested) {
-			continuation.resume(null, new CancellationException());
+			continuation.failAsync(new CancellationException());
 		} else {
 			continuation.resume(v, error);
 		}
@@ -87,7 +87,7 @@ class SuspendedRead<T> implements IContinuation<T> {
 			hostPage.data[hostIndex] = null;
 		}
 		// readMutex.release();
-		resume(null, null);
+		this.callSync();
 	}
 }
 
@@ -128,7 +128,7 @@ class Channel<T> {
 				if (suspendedRead == null) {
 					continue;
 				} else {
-					suspendedRead.resume(v, null);
+					suspendedRead.succeedAsync(v);
 					break;
 				}
 			}
@@ -145,7 +145,7 @@ class Channel<T> {
 			if (resuming == null) {
 				continue;
 			}
-			resuming.resume(null, null);
+			resuming.callSync();
 			if (writeQueue.length == 0) {
 				return resuming.value;
 			} else {

--- a/std/hxcoro/import.hx
+++ b/std/hxcoro/import.hx
@@ -1,0 +1,4 @@
+package hxcoro;
+
+using hxcoro.util.Convenience;
+import hxcoro.Coro.*;

--- a/std/hxcoro/task/CoroBaseTask.hx
+++ b/std/hxcoro/task/CoroBaseTask.hx
@@ -183,14 +183,14 @@ abstract class CoroBaseTask<T> extends AbstractTask<T> implements ICoroNode impl
 		}
 	}
 
+	function childrenCompleted() {
+		awaitingChildContinuation?.callSync();
+	}
+
 	// strategy dispatcher
 
 	function complete() {
 		nodeStrategy.complete(this);
-	}
-
-	function childrenCompleted() {
-		nodeStrategy.childrenCompleted(this);
 	}
 
 	function childSucceeds(child:AbstractTask) {

--- a/std/hxcoro/task/CoroBaseTask.hx
+++ b/std/hxcoro/task/CoroBaseTask.hx
@@ -139,9 +139,9 @@ abstract class CoroBaseTask<T> extends AbstractTask<T> implements ICoroNode impl
 	public function awaitContinuation(cont:IContinuation<T>) {
 		switch state {
 			case Completed:
-				cont.resume(result, null);
+				cont.succeedSync(result);
 			case Cancelled:
-				cont.resume(null, error);
+				cont.failSync(error);
 			case _:
 				awaitingContinuations ??= [];
 				awaitingContinuations.push(cont);
@@ -151,7 +151,7 @@ abstract class CoroBaseTask<T> extends AbstractTask<T> implements ICoroNode impl
 
 	@:coroutine public function awaitChildren() {
 		if (allChildrenCompleted) {
-			awaitingChildContinuation?.resume(null, null);
+			awaitingChildContinuation?.callSync();
 		}
 		startChildren();
 		Coro.suspend(cont -> awaitingChildContinuation = cont);
@@ -173,11 +173,11 @@ abstract class CoroBaseTask<T> extends AbstractTask<T> implements ICoroNode impl
 			awaitingContinuations = [];
 			if (error != null) {
 				for (cont in continuations) {
-					cont.resume(null, error);
+					cont.failAsync(error);
 				}
 			} else {
 				for (cont in continuations) {
-					cont.resume(result, null);
+					cont.succeedAsync(result);
 				}
 			}
 		}

--- a/std/hxcoro/task/CoroTask.hx
+++ b/std/hxcoro/task/CoroTask.hx
@@ -34,9 +34,9 @@ class CoroTask<T> extends CoroBaseTask<T> implements IContinuation<T> {
 			case Pending:
 				return;
 			case Returned:
-				resume(result.result, null);
+				this.succeedSync(result.result);
 			case Thrown:
-				resume(null, result.error);
+				this.failSync(result.error);
 		}
 	}
 

--- a/std/hxcoro/task/node/CoroChildStrategy.hx
+++ b/std/hxcoro/task/node/CoroChildStrategy.hx
@@ -13,10 +13,6 @@ class CoroChildStrategy implements INodeStrategy {
 		task.handleAwaitingContinuations();
 	}
 
-	public function childrenCompleted<T>(task:CoroBaseTask<T>) {
-		task.awaitingChildContinuation?.resume(null, null);
-	}
-
 	public function childSucceeds<T>(task:CoroBaseTask<T>, child:AbstractTask) {}
 
 	public function childErrors<T>(task:CoroBaseTask<T>, child:AbstractTask, cause:Exception) {

--- a/std/hxcoro/task/node/CoroScopeStrategy.hx
+++ b/std/hxcoro/task/node/CoroScopeStrategy.hx
@@ -13,10 +13,6 @@ class CoroScopeStrategy implements INodeStrategy {
 		task.handleAwaitingContinuations();
 	}
 
-	public function childrenCompleted<T>(task:CoroBaseTask<T>) {
-		task.awaitingChildContinuation?.resume(null, null);
-	}
-
 	public function childSucceeds<T>(task:CoroBaseTask<T>, child:AbstractTask) {}
 
 	public function childErrors<T>(task:CoroBaseTask<T>, child:AbstractTask, cause:Exception) {

--- a/std/hxcoro/task/node/CoroSupervisorStrategy.hx
+++ b/std/hxcoro/task/node/CoroSupervisorStrategy.hx
@@ -13,10 +13,6 @@ class CoroSupervisorStrategy implements INodeStrategy {
 		task.handleAwaitingContinuations();
 	}
 
-	public function childrenCompleted<T>(task:CoroBaseTask<T>) {
-		task.awaitingChildContinuation?.resume(null, null);
-	}
-
 	public function childSucceeds<T>(task:CoroBaseTask<T>, child:AbstractTask) {}
 
 	public function childErrors<T>(task:CoroBaseTask<T>, child:AbstractTask, cause:Exception) {}

--- a/std/hxcoro/task/node/INodeStrategy.hx
+++ b/std/hxcoro/task/node/INodeStrategy.hx
@@ -7,7 +7,6 @@ import hxcoro.task.CoroTask;
 
 interface INodeStrategy {
 	function complete<T>(task:CoroBaseTask<T>):Void;
-	function childrenCompleted<T>(task:CoroBaseTask<T>):Void;
 	function childSucceeds<T>(task:CoroBaseTask<T>, child:AbstractTask):Void;
 	function childErrors<T>(task:CoroBaseTask<T>, child:AbstractTask, cause:Exception):Void;
 	function childCancels<T>(task:CoroBaseTask<T>, child:AbstractTask, cause:CancellationException):Void;

--- a/std/hxcoro/util/Convenience.hx
+++ b/std/hxcoro/util/Convenience.hx
@@ -1,0 +1,71 @@
+package hxcoro.util;
+
+import haxe.coro.schedulers.Scheduler;
+import haxe.Exception;
+import haxe.coro.IContinuation;
+
+/**
+	A set of convenience functions for working with hxcoro data.
+**/
+class Convenience {
+	/**
+		Resumes `cont` with `result` immediately.
+	**/
+	static public inline function succeedSync<T>(cont:IContinuation<T>, result:T) {
+		cont.resume(result, null);
+	}
+
+	/**
+		Resumes `cont` with exception `error` immediately.
+	**/
+	static public inline function failSync<T>(cont:IContinuation<T>, error:Exception) {
+		cont.resume(null, error);
+	}
+
+	/**
+		Schedules `cont` to be resumed with `result`.
+
+		Scheduled functions do not increase the call stack and might be executed in a different
+		thread if the current dispatcher allows that.
+	**/
+	static public inline function succeedAsync<T>(cont:IContinuation<T>, result:T) {
+		resumeAsync(cont, result, null);
+	}
+
+	/**
+		Schedules `cont` to be resumed with exception `error`.
+
+		Scheduled functions do not increase the call stack and might be executed in a different
+		thread if the current dispatcher allows that.
+	**/
+	static public inline function failAsync<T>(cont:IContinuation<T>, error:Exception) {
+		resumeAsync(cont, null, error);
+	}
+
+	/**
+		Calls `cont` without any values immediately.
+	**/
+	static public inline function callSync<T>(cont:IContinuation<T>) {
+		cont.resume(null, null);
+	}
+
+	/**
+		Schedules `cont` to be resumed without any values.
+
+		Scheduled functions do not increase the call stack and might be executed in a different
+		thread if the current dispatcher allows that.
+	**/
+	static public inline function callAsync<T>(cont:IContinuation<T>) {
+		resumeAsync(cont, null, null);
+	}
+
+	/**
+		Schedules `cont` to be resumed with result `result` and exception `error`.
+
+		Scheduled functions do not increase the call stack and might be executed in a different
+		thread if the current dispatcher allows that.
+	**/
+	static public inline function resumeAsync<T>(cont:IContinuation<T>, result:T, error:Exception) {
+		cont.context.get(Scheduler.key).schedule(0, () -> cont.resume(result, error));
+	}
+}


### PR DESCRIPTION
Here's my take on what I find convenient. We distinguish two things:

1. The action be either of `succeed`, `fail` or `call`. The first two are obvious, `call` is the `resume(null, null)` case. There might be a better name for this.
2. The calling strategy is either `Sync` or `Async`. `Sync` is called directly, `Async` is scheduled instead.

The distinction of the latter is very important in our internal architecture, so I think it's good to make conscious decisions at every resume site about this. This already made me find several places where the resuming should be async.