### PR TITLE
Add a second type parameter to task structures

### DIFF
--- a/std/hxcoro/Coro.hx
+++ b/std/hxcoro/Coro.hx
@@ -57,7 +57,7 @@ class Coro {
 		});
 	}
 
-	@:coroutine static public function scope<T>(lambda:NodeLambda<T>):T {
+	@:coroutine static public function scope<T, C>(lambda:NodeLambda<T, C>):T {
 		return suspend(cont -> {
 			final context = cont.context;
 			final scope = new CoroScopeTask(context);
@@ -72,7 +72,7 @@ class Coro {
 		The task itself can still raise an exception. This is also true when calling
 		`child.await()` on a child that raises an exception.
 	**/
-	@:coroutine static public function supervisor<T>(lambda:NodeLambda<T>):T {
+	@:coroutine static public function supervisor<T, C>(lambda:NodeLambda<T, C>):T {
 		return suspend(cont -> {
 			final context = cont.context;
 			final scope = new CoroSupervisorTask(context);
@@ -89,7 +89,7 @@ class Coro {
 	 * @throws `hxcoro.exceptions.TimeoutException` If the timeout is exceeded.
 	 * @throws `haxe.ArgumentException` If the `ms` parameter is less than zero.
 	 */
-	@:coroutine public static function timeout<T>(ms:Int, lambda:NodeLambda<T>):T {
+	@:coroutine public static function timeout<T, C>(ms:Int, lambda:NodeLambda<T, C>):T {
 		return suspend(cont -> {
 			if (ms < 0) {
 				cont.resume(null, new ArgumentException('timeout must be positive'));

--- a/std/hxcoro/CoroRun.hx
+++ b/std/hxcoro/CoroRun.hx
@@ -13,11 +13,11 @@ private abstract RunnableContext(ElementTree) {
 		this = tree;
 	}
 
-	public function create<T>(lambda:NodeLambda<T>):IStartableCoroTask<T> {
+	public function create<T, C>(lambda:NodeLambda<T, C>):IStartableCoroTask<T> {
 		return new StartableCoroScopeTask(new Context(this), lambda);
 	}
 
-	public function run<T>(lambda:NodeLambda<T>):T {
+	public function run<T, C>(lambda:NodeLambda<T, C>):T {
 		return CoroRun.runWith(new Context(this), lambda);
 	}
 
@@ -50,11 +50,11 @@ class CoroRun {
 		return runScoped(_ -> lambda());
 	}
 
-	static public function runScoped<T>(lambda:NodeLambda<T>):T {
+	static public function runScoped<T, C>(lambda:NodeLambda<T, C>):T {
 		return runWith(defaultContext, lambda);
 	}
 
-	static public function runWith<T>(context:Context, lambda:NodeLambda<T>):T {
+	static public function runWith<T, C>(context:Context, lambda:NodeLambda<T, C>):T {
 		final schedulerComponent = new EventLoopScheduler();
 		final scope = new CoroScopeTask(context.clone().with(schedulerComponent));
 		scope.runNodeLambda(lambda);

--- a/std/hxcoro/task/AbstractTask.hx
+++ b/std/hxcoro/task/AbstractTask.hx
@@ -69,11 +69,11 @@ private class NoOpCancellationHandle implements ICancellationHandle {
 	and should be kept in a state where it could even be moved outside the hxcoro package. Also, `state` should
 	be treated like a truly private variable and only be modified from within this class.
 **/
-abstract class AbstractTask<T> implements ICancellationToken {
+abstract class AbstractTask<T, C = Any> implements ICancellationToken {
 	static final atomicId = new AtomicInt(1); // start with 1 so we can use 0 for "no task" situations
 	static final noOpCancellationHandle = new NoOpCancellationHandle();
 
-	var children:Null<Array<AbstractTask<Any>>>;
+	var children:Null<Array<AbstractTask<C>>>;
 	var cancellationCallbacks:Null<Array<CancellationHandle>>;
 	var state:TaskState;
 	var error:Null<Exception>;
@@ -269,15 +269,15 @@ abstract class AbstractTask<T> implements ICancellationToken {
 
 	abstract function childrenCompleted():Void;
 
-	abstract function childSucceeds(child:AbstractTask<Any>):Void;
+	abstract function childSucceeds(child:AbstractTask<C>):Void;
 
-	abstract function childErrors(child:AbstractTask<Any>, cause:Exception):Void;
+	abstract function childErrors(child:AbstractTask<C>, cause:Exception):Void;
 
-	abstract function childCancels(child:AbstractTask<Any>, cause:CancellationException):Void;
+	abstract function childCancels(child:AbstractTask<C>, cause:CancellationException):Void;
 
 	// called from child
 
-	function childCompletes(child:AbstractTask<Any>, processResult:Bool) {
+	function childCompletes(child:AbstractTask<C>, processResult:Bool) {
 		numCompletedChildren++;
 		if (processResult) {
 			if (child.error != null) {
@@ -297,7 +297,7 @@ abstract class AbstractTask<T> implements ICancellationToken {
 		}
 	}
 
-	function addChild(child:AbstractTask<Any>) {
+	function addChild(child:AbstractTask<C, Any>) {
 		final container = children ??= [];
 		final index = container.push(child);
 		child.indexInParent = index - 1;

--- a/std/hxcoro/task/CoroChildTask.hx
+++ b/std/hxcoro/task/CoroChildTask.hx
@@ -5,7 +5,7 @@ import haxe.Exception;
 import haxe.exceptions.CancellationException;
 import hxcoro.task.ICoroTask;
 
-class CoroChildTask<T> extends CoroTask<T> {
+class CoroChildTask<T, C> extends CoroTask<T, C> {
 	final parent:AbstractTask<Any>;
 
 	public function new(context:Context, parent:AbstractTask<Any>) {
@@ -16,9 +16,9 @@ class CoroChildTask<T> extends CoroTask<T> {
 
 	// called from parent
 
-	function childSucceeds(child:AbstractTask<Any>) {}
+	function childSucceeds(child:AbstractTask<C>) {}
 
-	function childErrors(child:AbstractTask<Any>, error:Exception) {
+	function childErrors(child:AbstractTask<C>, error:Exception) {
 		switch (state) {
 			case Created | Running | Completing:
 				// inherit child error
@@ -32,7 +32,7 @@ class CoroChildTask<T> extends CoroTask<T> {
 		}
 	}
 
-	function childCancels(child:AbstractTask<Any>, cause:CancellationException) {
+	function childCancels(child:AbstractTask<C>, cause:CancellationException) {
 		// Cancellation is often issued from the parent anyway, but I don't know if that's always the case
 		// Calling cancel is fine because it won't do anything if we're already cancelling
 		cancel(cause);
@@ -44,13 +44,13 @@ class CoroChildTask<T> extends CoroTask<T> {
 	}
 }
 
-class StartableCoroChildTask<T> extends CoroChildTask<T> implements IStartableCoroTask<T> {
-	final lambda:NodeLambda<T>;
+class StartableCoroChildTask<T, C> extends CoroChildTask<T, C> implements IStartableCoroTask<T> {
+	final lambda:NodeLambda<T, C>;
 
 	/**
 		Creates a new task using the provided `context` in order to execute `lambda`.
 	**/
-	public function new(context:Context, lambda:NodeLambda<T>, parent:AbstractTask<Any>) {
+	public function new(context:Context, lambda:NodeLambda<T, C>, parent:AbstractTask<Any>) {
 		super(context, parent);
 		this.lambda = lambda;
 	}

--- a/std/hxcoro/task/CoroScopeTask.hx
+++ b/std/hxcoro/task/CoroScopeTask.hx
@@ -5,7 +5,7 @@ import haxe.exceptions.CancellationException;
 import haxe.coro.context.Context;
 import hxcoro.task.ICoroTask;
 
-class CoroScopeTask<T> extends CoroTask<T> {
+class CoroScopeTask<T, C = Any> extends CoroTask<T, C> {
 	final parent:Null<AbstractTask<Any>>;
 
 	public function new(context:Context) {
@@ -17,16 +17,16 @@ class CoroScopeTask<T> extends CoroTask<T> {
 		}
 	}
 
-	function childSucceeds(_) {}
+	function childSucceeds(_:AbstractTask<C>) {}
 
-	function childErrors(_, error:Exception) {
+	function childErrors(_:AbstractTask<C>, error:Exception) {
 		if (this.error == null) {
 			this.error = error;
 			cancel();
 		}
 	}
 
-	function childCancels(_, cause:CancellationException) {}
+	function childCancels(_:AbstractTask<C>, cause:CancellationException) {}
 
 	function complete() {
 		parent?.childCompletes(this, false);
@@ -34,13 +34,13 @@ class CoroScopeTask<T> extends CoroTask<T> {
 	}
 }
 
-class StartableCoroScopeTask<T> extends CoroScopeTask<T> implements IStartableCoroTask<T> {
-	final lambda:NodeLambda<T>;
+class StartableCoroScopeTask<T, C = Any> extends CoroScopeTask<T, C> implements IStartableCoroTask<T> {
+	final lambda:NodeLambda<T, C>;
 
 	/**
 		Creates a new task using the provided `context` in order to execute `lambda`.
 	**/
-	public function new(context:Context, lambda:NodeLambda<T>) {
+	public function new(context:Context, lambda:NodeLambda<T, C>) {
 		super(context);
 		this.lambda = lambda;
 	}

--- a/std/hxcoro/task/CoroSupervisorTask.hx
+++ b/std/hxcoro/task/CoroSupervisorTask.hx
@@ -2,10 +2,10 @@ package hxcoro.task;
 
 import hxcoro.task.CoroScopeTask;
 
-class CoroSupervisorTask<T> extends CoroScopeTask<T> {
-	override function childErrors(_, _) {}
+class CoroSupervisorTask<T, C = Any> extends CoroScopeTask<T, C> {
+	override function childErrors(_:AbstractTask<C>, _) {}
 }
 
-class StartableCoroSupervisorTask<T> extends StartableCoroScopeTask<T> {
-	override function childErrors(_, _) {}
+class StartableCoroSupervisorTask<T = Any, C> extends StartableCoroScopeTask<T, C> {
+	override function childErrors(_:AbstractTask<C>, _) {}
 }

--- a/std/hxcoro/task/CoroTask.hx
+++ b/std/hxcoro/task/CoroTask.hx
@@ -11,12 +11,12 @@ import haxe.coro.context.IElement;
 import haxe.coro.schedulers.Scheduler;
 import haxe.coro.cancellation.CancellationToken;
 
-private class CoroTaskWith<T> implements ICoroNodeWith {
+private class CoroTaskWith<T, C> implements ICoroNodeWith<C> {
 	public var context(get, null):Context;
 
-	final task:CoroTask<T>;
+	final task:CoroTask<T, C>;
 
-	public function new(context:Context, task:CoroTask<T>) {
+	public function new(context:Context, task:CoroTask<T, C>) {
 		this.context = context;
 		this.task = task;
 	}
@@ -25,7 +25,7 @@ private class CoroTaskWith<T> implements ICoroNodeWith {
 		return context;
 	}
 
-	public function async<T>(lambda:NodeLambda<T>):ICoroTask<T> {
+	public function async<T:C, R>(lambda:NodeLambda<T, R>):ICoroTask<T> {
 		final child = new CoroChildTask(context, task);
 		context.get(Scheduler.key).schedule(0, () -> {
 			child.runNodeLambda(lambda);
@@ -33,7 +33,7 @@ private class CoroTaskWith<T> implements ICoroNodeWith {
 		return child;
 	}
 
-	public function lazy<T>(lambda:NodeLambda<T>):IStartableCoroTask<T> {
+	public function lazy<T:C, R>(lambda:NodeLambda<T, R>):IStartableCoroTask<T> {
 		return new CoroChildTask.StartableCoroChildTask(context, lambda, task);
 	}
 
@@ -45,7 +45,8 @@ private class CoroTaskWith<T> implements ICoroNodeWith {
 /**
 	CoroTask provides the basic functionality for coroutine tasks.
 **/
-abstract class CoroTask<T> extends AbstractTask<T> implements IContinuation<T> implements ICoroNode implements ICoroTask<T> implements IElement<CoroTask<Any>> {
+abstract class CoroTask<T, C = Any> extends AbstractTask<T, C> implements IContinuation<T> implements ICoroNode<C> implements ICoroTask<T>
+		implements IElement<CoroTask<Any>> {
 	public static final key = new Key<CoroTask<Any>>('Task');
 
 	/**
@@ -56,7 +57,7 @@ abstract class CoroTask<T> extends AbstractTask<T> implements IContinuation<T> i
 	var initialContext:Context;
 	var result:Null<T>;
 	var awaitingContinuations:Null<Array<IContinuation<T>>>;
-	var awaitingChildContinuation:Null<IContinuation<Any>>;
+	var awaitingChildContinuation:Null<IContinuation<C>>;
 	var wasResumed:Bool;
 
 	/**
@@ -107,7 +108,7 @@ abstract class CoroTask<T> extends AbstractTask<T> implements IContinuation<T> i
 		}
 	}
 
-	public function runNodeLambda(lambda:NodeLambda<T>) {
+	public function runNodeLambda(lambda:NodeLambda<T, C>) {
 		final result = lambda(this, this);
 		start();
 		switch result.state {
@@ -124,15 +125,15 @@ abstract class CoroTask<T> extends AbstractTask<T> implements IContinuation<T> i
 		Creates a lazy child task to execute `lambda`. The child task does not execute until its `start`
 		method is called. This occurrs automatically once this task has finished execution.
 	**/
-	public function lazy<T>(lambda:NodeLambda<T>):IStartableCoroTask<T> {
+	public function lazy<T:C, R>(lambda:NodeLambda<T, R>):IStartableCoroTask<T> {
 		return new CoroChildTask.StartableCoroChildTask(initialContext, lambda, this);
 	}
 
 	/**
 		Creates a child task to execute `lambda` and starts it automatically.
 	**/
-	public function async<T>(lambda:NodeLambda<T>):ICoroTask<T> {
-		final child = new CoroChildTask<T>(initialContext, this);
+	public function async<T:C, R>(lambda:NodeLambda<T, R>):ICoroTask<T> {
+		final child = new CoroChildTask<T, R>(initialContext, this);
 		initialContext.get(Scheduler.key).schedule(0, () -> {
 			child.runNodeLambda(lambda);
 		});

--- a/std/hxcoro/task/ICoroNode.hx
+++ b/std/hxcoro/task/ICoroNode.hx
@@ -5,14 +5,14 @@ import haxe.coro.context.Context;
 import haxe.coro.context.IElement;
 import hxcoro.task.ICoroTask;
 
-interface ICoroNodeWith {
+interface ICoroNodeWith<C = Any> {
 	var context(get, null):Context;
-	function async<T>(lambda:NodeLambda<T>):ICoroTask<T>;
-	function lazy<T>(lambda:NodeLambda<T>):IStartableCoroTask<T>;
-	function with(...elements:IElement<Any>):ICoroNodeWith;
+	function async<T:C, R>(lambda:NodeLambda<T, R>):ICoroTask<T>;
+	function lazy<T:C, R>(lambda:NodeLambda<T, R>):IStartableCoroTask<T>;
+	function with(...elements:IElement<Any>):ICoroNodeWith<C>;
 }
 
-interface ICoroNode extends ICoroNodeWith {
+interface ICoroNode<C = Any> extends ICoroNodeWith<C> {
 	var id(get, never):Int;
 	@:coroutine function awaitChildren():Void;
 	function cancel(?cause:CancellationException):Void;

--- a/std/hxcoro/task/NodeLambda.hx
+++ b/std/hxcoro/task/NodeLambda.hx
@@ -2,4 +2,4 @@ package hxcoro.task;
 
 import haxe.coro.Coroutine;
 
-typedef NodeLambda<T> = Coroutine<(node:ICoroNode) -> T>;
+typedef NodeLambda<T, C = Any> = Coroutine<(node:ICoroNode<C>) -> T>;


### PR DESCRIPTION
This adds a type parameter `C` to various places, which represents the minimum type child tasks may have. I initially thought that this might be too annoying to do, but with default type parameters I feel like the syntactic overhead is acceptable.

This allows restricting the return type of child tasks:

```haxe
function main() {
	CoroRun.runScoped((node:ICoroNode<Int>) -> {
		node.async(_ -> 1); // ok
		node.async(_ -> "1"); // String should be Int
	});
}
```

While this may not look especially enticing, what this will allow us to do is define aggregate tasks that work with the return type of their children in some way. For example, here's a custom coroutine which simply resolves to the value of its first completing child:

```haxe
import haxe.exceptions.CancellationException;
import hxcoro.task.CoroScopeTask;
import hxcoro.task.NodeLambda;
import hxcoro.task.AbstractTask;
import hxcoro.Coro.*;
import hxcoro.CoroRun;
import haxe.Exception;

class CoroFirstChildTask<C> extends CoroScopeTask<C, C> {
	override function childSucceeds(child:AbstractTask<C, Any>) {
		if (result == null) {
			result = child.get();
			cancelChildren();
		}
	}

	override function childErrors(_:AbstractTask<C, Any>, error:Exception) {}

	override function childCancels(_:AbstractTask<C, Any>, cause:CancellationException) {}

	override function resume(result:C, error:Exception) {
		wasResumed = true;
		beginCompleting();
		checkCompletion();
		// ignore actual result, it should be Void/Unit
	}
}

@:coroutine function firstChild<T>(lambda:NodeLambda<T, T>):T {
	return suspend(cont -> {
		final context = cont.context;
		final scope = new CoroFirstChildTask(context);
		scope.runNodeLambda(lambda);
		scope.awaitContinuation(cont);
	});
}

function main() {
	CoroRun.runScoped(node -> {
		final result = firstChild(node -> {
			for (_ in 0...10) {
				node.async(node -> {
					final d = Std.random(500);
					trace('delaying task ${node.id} by $d');
					delay(d);
					d;
				});
			};
			node.async(_ -> {
				trace('delaying task ${node.id} by 1000, it would fail afterwards');
				delay(1000);
				throw 'oh no';
			});
			// node.async(_ -> "1"); // would fail
			0; // needed at the moment because IContinuation<T> is tied to CoroTask<T>, but that's a separate issue
		});
		trace(result);
	});
}
```

```
source/Main.hx:44: delaying task 3 by 354
source/Main.hx:44: delaying task 4 by 181
source/Main.hx:44: delaying task 5 by 330
source/Main.hx:44: delaying task 6 by 234
source/Main.hx:44: delaying task 7 by 229
source/Main.hx:44: delaying task 8 by 296
source/Main.hx:44: delaying task 9 by 24
source/Main.hx:44: delaying task 10 by 322
source/Main.hx:44: delaying task 11 by 309
source/Main.hx:44: delaying task 12 by 73
source/Main.hx:50: delaying task 2 by 1000, it would fail afterwards
source/Main.hx:57: 24
```