### PR TITLE
Add ILocalContext

### DIFF
--- a/std/haxe/coro/context/Context.hx
+++ b/std/haxe/coro/context/Context.hx
@@ -131,6 +131,10 @@ abstract AdjustableContext(ElementTree) {
 		return abstract;
 	}
 
+	public function get<T>(key:Key<T>):T {
+		return cast this.get(key.id);
+	}
+
 	public function with(...elements:IElement<Any>) {
 		for (element in elements) {
 			this.set(element.getKey().id, element);

--- a/std/hxcoro/task/CoroBaseTask.hx
+++ b/std/hxcoro/task/CoroBaseTask.hx
@@ -8,6 +8,7 @@ import haxe.Exception;
 import haxe.exceptions.CancellationException;
 import haxe.coro.IContinuation;
 import haxe.coro.context.Context;
+import haxe.coro.context.Key;
 import haxe.coro.context.IElement;
 import haxe.coro.schedulers.Scheduler;
 import haxe.coro.cancellation.CancellationToken;
@@ -46,13 +47,14 @@ private class CoroTaskWith<T> implements ICoroNodeWith {
 /**
 	CoroTask provides the basic functionality for coroutine tasks.
 **/
-abstract class CoroBaseTask<T> extends AbstractTask<T> implements ICoroNode implements ICoroTask<T> implements IElement<CoroBaseTask<Any>> {
+abstract class CoroBaseTask<T> extends AbstractTask<T> implements ICoroNode implements ICoroTask<T> implements ILocalContext implements IElement<CoroBaseTask<Any>> {
 	/**
 		This task's immutable `Context`.
 	**/
 	public var context(get, null):Context;
 
 	final nodeStrategy:INodeStrategy;
+	var coroLocalContext:Null<AdjustableContext>;
 	var initialContext:Context;
 	var result:Null<T>;
 	var awaitingContinuations:Null<Array<IContinuation<T>>>;
@@ -80,6 +82,17 @@ abstract class CoroBaseTask<T> extends AbstractTask<T> implements ICoroNode impl
 
 	public function getKey() {
 		return CoroTask.key;
+	}
+
+	public function getLocalElement<T>(key:Key<T>):Null<T> {
+		return coroLocalContext?.get(key);
+	}
+
+	public function setLocalElement<T>(key:Key<T>, element:T) {
+		if (coroLocalContext == null) {
+			coroLocalContext = Context.create();
+		}
+		coroLocalContext.add(key, element);
 	}
 
 	/**

--- a/std/hxcoro/task/CoroBaseTask.hx
+++ b/std/hxcoro/task/CoroBaseTask.hx
@@ -44,6 +44,10 @@ private class CoroTaskWith<T> implements ICoroNodeWith {
 	}
 }
 
+private class CoroKeys {
+	static public final awaitingChildContinuation = new Key<IContinuation<Any>>("AwaitingChildContinuation");
+}
+
 /**
 	CoroTask provides the basic functionality for coroutine tasks.
 **/
@@ -58,7 +62,6 @@ abstract class CoroBaseTask<T> extends AbstractTask<T> implements ICoroNode impl
 	var initialContext:Context;
 	var result:Null<T>;
 	var awaitingContinuations:Null<Array<IContinuation<T>>>;
-	var awaitingChildContinuation:Null<IContinuation<Any>>;
 
 	/**
 		Creates a new task using the provided `context`.
@@ -164,10 +167,10 @@ abstract class CoroBaseTask<T> extends AbstractTask<T> implements ICoroNode impl
 
 	@:coroutine public function awaitChildren() {
 		if (allChildrenCompleted) {
-			awaitingChildContinuation?.callSync();
+			getLocalElement(CoroKeys.awaitingChildContinuation)?.callSync();
 		}
 		startChildren();
-		Coro.suspend(cont -> awaitingChildContinuation = cont);
+		Coro.suspend(cont -> setLocalElement(CoroKeys.awaitingChildContinuation, cont));
 	}
 
 	/**
@@ -197,7 +200,7 @@ abstract class CoroBaseTask<T> extends AbstractTask<T> implements ICoroNode impl
 	}
 
 	function childrenCompleted() {
-		awaitingChildContinuation?.callSync();
+		getLocalElement(CoroKeys.awaitingChildContinuation)?.callSync();
 	}
 
 	// strategy dispatcher

--- a/std/hxcoro/task/ICoroNode.hx
+++ b/std/hxcoro/task/ICoroNode.hx
@@ -12,7 +12,7 @@ interface ICoroNodeWith {
 	function with(...elements:IElement<Any>):ICoroNodeWith;
 }
 
-interface ICoroNode extends ICoroNodeWith {
+interface ICoroNode extends ICoroNodeWith extends ILocalContext {
 	var id(get, never):Int;
 	@:coroutine function awaitChildren():Void;
 	function cancel(?cause:CancellationException):Void;

--- a/std/hxcoro/task/ICoroTask.hx
+++ b/std/hxcoro/task/ICoroTask.hx
@@ -3,7 +3,7 @@ package hxcoro.task;
 import haxe.Exception;
 import haxe.exceptions.CancellationException;
 
-interface ICoroTask<T> {
+interface ICoroTask<T> extends ILocalContext {
 	var id(get, never):Int;
 	function cancel(?cause:CancellationException):Void;
 	@:coroutine function await():T;

--- a/std/hxcoro/task/ILocalContext.hx
+++ b/std/hxcoro/task/ILocalContext.hx
@@ -1,0 +1,8 @@
+package hxcoro.task;
+
+import haxe.coro.context.Key;
+
+interface ILocalContext {
+	function getLocalElement<T>(key:Key<T>):Null<T>;
+	function setLocalElement<T>(key:Key<T>, element:T):Void;
+}

--- a/tests/misc/coroutines/src/Main.hx
+++ b/tests/misc/coroutines/src/Main.hx
@@ -31,6 +31,7 @@ function main() {
 	runner.addCases("concurrent");
 	runner.addCases("components");
 	runner.addCases("structured");
+	runner.addCases("features");
 
     utest.ui.Report.create(runner);
     runner.run();

--- a/tests/misc/coroutines/src/features/TestCoroLocalContext.hx
+++ b/tests/misc/coroutines/src/features/TestCoroLocalContext.hx
@@ -1,0 +1,39 @@
+package features;
+
+import hxcoro.task.ICoroNode;
+import haxe.coro.context.Key;
+import hxcoro.task.ILocalContext;
+
+class TestCoroLocalContext extends utest.Test {
+	public function test() {
+		final stackKey = new Key<Array<String>>("stack");
+
+		function visit(node:ILocalContext) {
+			final element = node.getLocalElement(stackKey);
+			if (element == null) {
+				node.setLocalElement(stackKey, ["first time"]);
+				return;
+			}
+			if (element.length == 1) {
+				element.push("second time");
+			} else {
+				element.push('number ${element.length + 1}');
+			}
+		}
+
+		final result = CoroRun.runScoped(node -> {
+			final child1 = node.async(node -> {
+				visit(node);
+				visit(node);
+				visit(node);
+				node.getLocalElement(stackKey);
+			});
+			final child2 = node.async(node -> { });
+			visit(child2);
+			visit(child2);
+			Assert.same(["first time", "second time"], child2.getLocalElement(stackKey));
+			child1.await();
+		});
+		Assert.same(["first time", "second time", "number 3"], result);
+	}
+}


### PR DESCRIPTION
This allows adding a local context to tasks, which works exactly like the normal context but is mutable. It's a straightforward way to associate arbitrary data with tasks after they've been created:

```haxe
import haxe.Timer;
import haxe.coro.context.Key;
import hxcoro.task.ICoroNode;
import hxcoro.CoroRun;
import hxcoro.Coro.*;

final timeKey = new Key<Array<Float>>("time");

function visit(node:ICoroNode) {
	final element = node.getLocalElement(timeKey);
	final now = haxe.Timer.stamp();
	if (element != null) {
		trace('You were here ${element.length} time${element.length > 1 ? "s" : ""} before, '
		    + ' most recently ${Std.string(now - element[element.length - 1]).substr(0, 5)}ms ago');
		element.push(now);
	} else {
		trace("You're here for the first time!");
		node.setLocalElement(timeKey, [now]);
	}
}

function main() {
	CoroRun.runScoped(node -> {
		visit(node);
		delay(1000);
		visit(node);
		delay(4);
		visit(node);
	});
}
```

```
source/Main.hx:17: You're here for the first time!
source/Main.hx:13: You were here 1 time before, most recently 1.005ms ago
source/Main.hx:13: You were here 2 times before, most recently 0.005ms ago
```