### PR TITLE
Millisecond Schedulers

### DIFF
--- a/std/haxe/coro/schedulers/EventLoopScheduler.hx
+++ b/std/haxe/coro/schedulers/EventLoopScheduler.hx
@@ -9,7 +9,7 @@ private class ScheduledEvent implements ISchedulerHandle {
 	final closure : CloseClosure;
 	final func : Lambda;
 	var closed : Bool;
-	public final runTime : Float;
+	public final runTime : Int64;
 	public var next : Null<ScheduledEvent>;
 	public var previous : Null<ScheduledEvent>;
 
@@ -97,7 +97,7 @@ class EventLoopScheduler extends Scheduler {
 		closeClosure = close;
 	}
 
-    public function schedule(ms:Int, func:()->Void):ISchedulerHandle {
+    public function schedule(ms:Int64, func:()->Void):ISchedulerHandle {
 		if (ms < 0) {
 			throw new ArgumentException("Time must be greater or equal to zero");
 		} else if (ms == 0) {
@@ -107,7 +107,7 @@ class EventLoopScheduler extends Scheduler {
 			return noOpHandle;
 		}
 
-		final event = new ScheduledEvent(closeClosure, func, now() + (ms / 1000));
+		final event = new ScheduledEvent(closeClosure, func, now() + ms);
 
 		futureMutex.acquire();
 		if (first == null) {
@@ -160,7 +160,7 @@ class EventLoopScheduler extends Scheduler {
     }
 
 	public function now() {
-		return Timer.stamp();
+		return Timer.milliseconds();
 	}
 
 	public function run() {

--- a/std/haxe/coro/schedulers/Scheduler.hx
+++ b/std/haxe/coro/schedulers/Scheduler.hx
@@ -8,9 +8,9 @@ abstract class Scheduler implements IElement<Scheduler> {
 
 	function new() {}
 
-	public abstract function schedule(ms:Int, func:() -> Void):ISchedulerHandle;
+	public abstract function schedule(ms:Int64, func:() -> Void):ISchedulerHandle;
 
-	public abstract function now():Float;
+	public abstract function now():Int64;
 
 	public function getKey() {
 		return key;

--- a/std/haxe/coro/schedulers/VirtualTimeScheduler.hx
+++ b/std/haxe/coro/schedulers/VirtualTimeScheduler.hx
@@ -8,7 +8,7 @@ class VirtualTimeScheduler extends EventLoopScheduler {
 	public function new() {
 		super();
 
-		currentTime = 0;
+		currentTime = 0i64;
 	}
 
 	public override function now() {

--- a/std/haxe/coro/schedulers/VirtualTimeScheduler.hx
+++ b/std/haxe/coro/schedulers/VirtualTimeScheduler.hx
@@ -3,7 +3,7 @@ package haxe.coro.schedulers;
 import haxe.exceptions.ArgumentException;
 
 class VirtualTimeScheduler extends EventLoopScheduler {
-	var currentTime : Float;
+	var currentTime : Int64;
 
 	public function new() {
 		super();
@@ -20,21 +20,21 @@ class VirtualTimeScheduler extends EventLoopScheduler {
 			throw new ArgumentException("Time must be greater or equal to zero");
 		}
 
-		virtualRun(currentTime + (ms / 1000));
+		virtualRun(currentTime + ms);
 	}
 
 	public function advanceTo(ms:Int) {
 		if (ms < 0) {
 			throw new ArgumentException("Time must be greater or equal to zero");
 		}
-		if ((ms / 1000) < currentTime) {
+		if (ms < currentTime) {
 			throw new ArgumentException("Cannot travel back in time");
 		}
 
-		virtualRun(ms / 1000);
+		virtualRun(ms);
 	}
 
-	function virtualRun(endTime : Float) {
+	function virtualRun(endTime : Int64) {
 		while (true) {
 			for (event in zeroEvents.flip()) {
 				event();

--- a/tests/misc/coroutines/src/Helper.hx
+++ b/tests/misc/coroutines/src/Helper.hx
@@ -4,9 +4,3 @@ import haxe.coro.schedulers.VirtualTimeScheduler;
 function mapCalls<TArg,TRet>(args:Array<TArg>, f:Coroutine<TArg->TRet>):Array<TRet> {
 	return [for (arg in args) f(arg)];
 }
-
-class SchedulerTools {
-	static public function nowMs(scheduler:VirtualTimeScheduler) {
-		return Std.int(scheduler.now() * 1000);
-	}
-}

--- a/tests/misc/coroutines/src/TestGenerator.hx
+++ b/tests/misc/coroutines/src/TestGenerator.hx
@@ -20,7 +20,7 @@ class ImmediateScheduler extends Scheduler {
 	}
 
 	public function now() {
-		return 0.0;
+		return 0i64;
 	}
 }
 

--- a/tests/misc/coroutines/src/TestGenerator.hx
+++ b/tests/misc/coroutines/src/TestGenerator.hx
@@ -1,3 +1,4 @@
+import haxe.Int64;
 import haxe.coro.schedulers.Scheduler;
 import hxcoro.task.CoroTask;
 import haxe.coro.context.Context;
@@ -10,7 +11,7 @@ class ImmediateScheduler extends Scheduler {
 		super();
 	}
 
-	public function schedule(ms:Int, f:() -> Void) {
+	public function schedule(ms:Int64, f:() -> Void) {
 		if (ms != 0) {
 			throw 'Only immediate scheduling is allowed in this scheduler';
 		}

--- a/tests/misc/coroutines/src/concurrent/TestMutex.hx
+++ b/tests/misc/coroutines/src/concurrent/TestMutex.hx
@@ -20,7 +20,7 @@ class TestMutex extends utest.Test {
 		var scheduler = new VirtualTimeScheduler();
 		final lines = [];
 		function report(s:String) {
-			final now = scheduler.nowMs();
+			final now = scheduler.now();
 			lines.push('$now: $s');
 		}
 		final task = CoroRun.with(scheduler).create(node -> {
@@ -140,7 +140,7 @@ class TestMutex extends utest.Test {
 		var scheduler = new VirtualTimeScheduler();
 		final lines = [];
 		function report(s:String) {
-			final now = scheduler.nowMs();
+			final now = scheduler.now();
 			lines.push('$now: $s');
 		}
 		final task = CoroRun.with(scheduler).create(node -> {

--- a/tests/misc/coroutines/src/ds/TestChannel.hx
+++ b/tests/misc/coroutines/src/ds/TestChannel.hx
@@ -124,7 +124,8 @@ class TestChannel extends utest.Test {
 
 		scheduler.advanceBy(1);
 		Assert.same([], actual);
-		Assert.same([100i64], exceptions);
+		Assert.equals(1, exceptions.length);
+		Assert.equals(100i64, exceptions[0]);
 
 		scheduler.advanceBy(100);
 		Assert.same([ 'World' ], actual);
@@ -164,7 +165,8 @@ class TestChannel extends utest.Test {
 		scheduler.advanceBy(100);
 
 		Assert.same([ 'Hello' ], actual);
-		Assert.same([100i64], exceptions);
+		Assert.equals(1, exceptions.length);
+		Assert.equals(100i64, exceptions[0]);
 		Assert.isFalse(task.isActive());
 	}
 }

--- a/tests/misc/coroutines/src/ds/TestChannel.hx
+++ b/tests/misc/coroutines/src/ds/TestChannel.hx
@@ -104,7 +104,7 @@ class TestChannel extends utest.Test {
 						channel.write('Hello');
 					});
 				} catch (_:TimeoutException) {
-					exceptions.push(scheduler.nowMs());
+					exceptions.push(scheduler.now());
 				}
 			});
 
@@ -144,7 +144,7 @@ class TestChannel extends utest.Test {
 						return channel.read();
 					});
 				} catch(_:TimeoutException) {
-					exceptions.push(scheduler.nowMs());
+					exceptions.push(scheduler.now());
 					"";
 				}
 			});

--- a/tests/misc/coroutines/src/ds/TestChannel.hx
+++ b/tests/misc/coroutines/src/ds/TestChannel.hx
@@ -125,7 +125,7 @@ class TestChannel extends utest.Test {
 		scheduler.advanceBy(1);
 		Assert.same([], actual);
 		Assert.equals(1, exceptions.length);
-		Assert.equals(100i64, exceptions[0]);
+		Assert.isTrue(100i64 == exceptions[0]);
 
 		scheduler.advanceBy(100);
 		Assert.same([ 'World' ], actual);
@@ -166,7 +166,7 @@ class TestChannel extends utest.Test {
 
 		Assert.same([ 'Hello' ], actual);
 		Assert.equals(1, exceptions.length);
-		Assert.equals(100i64, exceptions[0]);
+		Assert.isTrue(100i64 == exceptions[0]);
 		Assert.isFalse(task.isActive());
 	}
 }

--- a/tests/misc/coroutines/src/ds/TestChannel.hx
+++ b/tests/misc/coroutines/src/ds/TestChannel.hx
@@ -124,7 +124,7 @@ class TestChannel extends utest.Test {
 
 		scheduler.advanceBy(1);
 		Assert.same([], actual);
-		Assert.same([100], exceptions);
+		Assert.same([100i64], exceptions);
 
 		scheduler.advanceBy(100);
 		Assert.same([ 'World' ], actual);
@@ -164,7 +164,7 @@ class TestChannel extends utest.Test {
 		scheduler.advanceBy(100);
 
 		Assert.same([ 'Hello' ], actual);
-		Assert.same([100], exceptions);
+		Assert.same([100i64], exceptions);
 		Assert.isFalse(task.isActive());
 	}
 }

--- a/tests/misc/coroutines/src/import.hx
+++ b/tests/misc/coroutines/src/import.hx
@@ -3,5 +3,3 @@ import utest.Async;
 import haxe.coro.Coroutine;
 import hxcoro.Coro.*;
 import hxcoro.CoroRun;
-
-using Helper.SchedulerTools;

--- a/tests/misc/coroutines/src/issues/aidan/Issue126.hx
+++ b/tests/misc/coroutines/src/issues/aidan/Issue126.hx
@@ -63,7 +63,7 @@ class Issue126 extends utest.Test {
 		final task = CoroRun.with(scheduler).create(node -> {
 			final channel = new Channel(0);
 			@:coroutine function log(s:String) {
-				channel.write('${scheduler.nowMs()}: $s');
+				channel.write('${scheduler.now()}: $s');
 			}
 			final junction = new Junction(true);
 			final leftChild = node.async(node -> {

--- a/tests/misc/coroutines/src/issues/aidan/Issue126.hx
+++ b/tests/misc/coroutines/src/issues/aidan/Issue126.hx
@@ -63,7 +63,7 @@ class Issue126 extends utest.Test {
 		final task = CoroRun.with(scheduler).create(node -> {
 			final channel = new Channel(0);
 			@:coroutine function log(s:String) {
-				channel.write('${scheduler.now()}: $s');
+				channel.write('${@:privateAccess scheduler.now().toString()}: $s');
 			}
 			final junction = new Junction(true);
 			final leftChild = node.async(node -> {
@@ -100,6 +100,9 @@ class Issue126 extends utest.Test {
 		while (task.isActive()) {
 			scheduler.advanceBy(1);
 		}
+
+		trace(task.get());
+
 		Assert.same([
 			   "0: left",
 			 "500: left",

--- a/tests/misc/coroutines/src/structured/TestCancellingSuspend.hx
+++ b/tests/misc/coroutines/src/structured/TestCancellingSuspend.hx
@@ -24,7 +24,7 @@ class TestCancellingSuspend extends utest.Test {
 
 		scheduler.advanceBy(100);
 
-		Assert.same([ 100 ], actual);
+		Assert.same([ 100i64 ], actual);
 		Assert.isFalse(task.isActive());
 		Assert.isOfType(task.getError(), CancellationException);
 	}

--- a/tests/misc/coroutines/src/structured/TestCancellingSuspend.hx
+++ b/tests/misc/coroutines/src/structured/TestCancellingSuspend.hx
@@ -24,7 +24,8 @@ class TestCancellingSuspend extends utest.Test {
 
 		scheduler.advanceBy(100);
 
-		Assert.same([ 100i64 ], actual);
+		Assert.equals(1, actual.length);
+		Assert.equals(100i64, actual[0]);
 		Assert.isFalse(task.isActive());
 		Assert.isOfType(task.getError(), CancellationException);
 	}

--- a/tests/misc/coroutines/src/structured/TestCancellingSuspend.hx
+++ b/tests/misc/coroutines/src/structured/TestCancellingSuspend.hx
@@ -24,7 +24,7 @@ class TestCancellingSuspend extends utest.Test {
 
 		scheduler.advanceBy(100);
 
-		Assert.same([ 0.1 ], actual);
+		Assert.same([ 100 ], actual);
 		Assert.isFalse(task.isActive());
 		Assert.isOfType(task.getError(), CancellationException);
 	}

--- a/tests/misc/coroutines/src/structured/TestCancellingSuspend.hx
+++ b/tests/misc/coroutines/src/structured/TestCancellingSuspend.hx
@@ -25,7 +25,7 @@ class TestCancellingSuspend extends utest.Test {
 		scheduler.advanceBy(100);
 
 		Assert.equals(1, actual.length);
-		Assert.equals(100i64, actual[0]);
+		Assert.isTrue(100i64 == actual[0]);
 		Assert.isFalse(task.isActive());
 		Assert.isOfType(task.getError(), CancellationException);
 	}


### PR DESCRIPTION
Closes #120 

Schedulers now use Int64 ms for everything, no weird mix of float seconds and ms.

Might dig out that channel benchmark to see if this has a noticable effect on targets (I imagine for those emulating Int64 it will).