### PR TITLE
[mad science] Get rid of explicit .key expressions

### DIFF
--- a/std/haxe/coro/BaseContinuation.hx
+++ b/std/haxe/coro/BaseContinuation.hx
@@ -42,7 +42,7 @@ abstract class BaseContinuation<T> extends SuspensionResult<T> implements IConti
         result     = null;
         recursing  = false;
 		startedException = false;
-		scheduler = completion.context.get(Scheduler.key);
+		scheduler = completion.context.get(Scheduler);
     }
 
 	inline function get_context() {
@@ -147,7 +147,7 @@ abstract class BaseContinuation<T> extends SuspensionResult<T> implements IConti
 				return;
 		}
 		exception.stack = stack;
-		context.get(StackTraceManager.key).insertIndex = insertIndex;
+		context.get(StackTraceManager).insertIndex = insertIndex;
 	}
 
     public function buildCallStack() {
@@ -157,7 +157,7 @@ abstract class BaseContinuation<T> extends SuspensionResult<T> implements IConti
 		if (startedException) {
 			return;
 		}
-		var stackTraceManager = context.get(StackTraceManager.key);
+		var stackTraceManager = context.get(StackTraceManager);
 		// Can happen in the case of ImmediateSuspensionResult.withError
 		if (stackTraceManager.insertIndex == null) {
 			startException(error);

--- a/std/haxe/coro/context/Key.hx
+++ b/std/haxe/coro/context/Key.hx
@@ -31,7 +31,7 @@ extern abstract Key<T>(KeyImpl<T>) {
 		this = KeyImpl.createNew(name);
 	}
 
-	@:from static public inline function fromClass<T, K, C:(Class<T> & WithKey<K>)>(c:C):Key<K> {
+	@:from static public inline function fromClass<K, C:(Class<Any> & WithKey<K>)>(c:C):Key<K> {
 		return c.key;
 	}
 }

--- a/std/haxe/coro/context/Key.hx
+++ b/std/haxe/coro/context/Key.hx
@@ -20,10 +20,18 @@ class KeyImpl<T> {
 	}
 }
 
+private typedef WithKey<K> = {
+	final key:Key<K>;
+}
+
 @:forward
 @:forward.statics
 extern abstract Key<T>(KeyImpl<T>) {
 	public inline function new(name:String) {
 		this = KeyImpl.createNew(name);
+	}
+
+	@:from static public inline function fromClass<T, K, C:(Class<T> & WithKey<K>)>(c:C):Key<K> {
+		return c.key;
 	}
 }

--- a/std/haxe/coro/continuations/RacingContinuation.hx
+++ b/std/haxe/coro/continuations/RacingContinuation.hx
@@ -15,7 +15,7 @@ class RacingContinuation<T> extends SuspensionResult<T> implements IContinuation
 	public function new(inputCont:IContinuation<T>) {
 		this.inputCont = inputCont;
 		mutex = new Mutex();
-		scheduler = context.get(Scheduler.key);
+		scheduler = context.get(Scheduler);
 	}
 
 	inline function get_context() {

--- a/std/hxcoro/Coro.hx
+++ b/std/hxcoro/Coro.hx
@@ -33,12 +33,12 @@ class Coro {
 	}
 
 	static function cancellationRequested(cont:IContinuation<Any>) {
-		return cont.context.get(CancellationToken.key)?.isCancellationRequested;
+		return cont.context.get(CancellationToken)?.isCancellationRequested;
 	}
 
 	@:coroutine @:coroutine.nothrow public static function delay(ms:Int):Void {
 		suspendCancellable(cont -> {
-			final handle = cont.context.get(Scheduler.key).schedule(ms, () -> {
+			final handle = cont.context.get(Scheduler).schedule(ms, () -> {
 				cont.callSync();
 			});
 
@@ -50,7 +50,7 @@ class Coro {
 
 	@:coroutine @:coroutine.nothrow public static function yield():Void {
 		suspend(cont -> {
-			cont.context.get(Scheduler.key).schedule(0, () -> {
+			cont.context.get(Scheduler).schedule(0, () -> {
 				cont.failSync(cancellationRequested(cont) ? new CancellationException() : null);
 			});
 		});
@@ -103,7 +103,7 @@ class Coro {
 
 			final context = cont.context;
 			final scope = new CoroTask(context, CoroTask.CoroScopeStrategy);
-			final handle = context.get(Scheduler.key).schedule(ms, () -> {
+			final handle = context.get(Scheduler).schedule(ms, () -> {
 				scope.cancel(new TimeoutException());
 			});
 

--- a/std/hxcoro/concurrent/CoroSemaphore.hx
+++ b/std/hxcoro/concurrent/CoroSemaphore.hx
@@ -23,7 +23,7 @@ class CoroSemaphore {
 			return;
 		}
 		suspendCancellable(cont -> {
-			final task = cont.context.get(CoroTask.key);
+			final task = cont.context.get(CoroTask);
 			dequeMutex.acquire();
 			if (deque == null) {
 				deque = new PagedDeque();
@@ -61,7 +61,7 @@ class CoroSemaphore {
 			}
 			// a continuation waits for this mutex, wake it up now
 			final cont = deque.pop();
-			final ct = cont.context.get(CancellationToken.key);
+			final ct = cont.context.get(CancellationToken);
 			if (ct.isCancellationRequested) {
 				// ignore, back to the loop
 			} else {

--- a/std/hxcoro/continuations/CancellingContinuation.hx
+++ b/std/hxcoro/continuations/CancellingContinuation.hx
@@ -33,7 +33,7 @@ class CancellingContinuation<T> implements ICancellableContinuation<T> implement
 	public var onCancellationRequested (default, set) : ()->Void;
 
 	function set_onCancellationRequested(f : ()->Void) {
-		return if (cont.context.get(CancellationToken.key).isCancellationRequested) {
+		return if (cont.context.get(CancellationToken).isCancellationRequested) {
 			f();
 
 			f;
@@ -50,11 +50,11 @@ class CancellingContinuation<T> implements ICancellableContinuation<T> implement
 	public function new(cont) {
 		this.state  = new AtomicInt(Active);
 		this.cont   = cont;
-		this.handle = this.cont.context.get(CancellationToken.key).onCancellationRequested(this);
+		this.handle = this.cont.context.get(CancellationToken).onCancellationRequested(this);
 	}
 
 	public function resume(result:T, error:Exception) {
-		context.get(Scheduler.key).schedule(0, () -> {
+		context.get(Scheduler).schedule(0, () -> {
 			if (state.compareExchange(Active, Resumed) == Active) {
 				handle.close();
 				cont.resume(result, error);

--- a/std/hxcoro/ds/Channel.hx
+++ b/std/hxcoro/ds/Channel.hx
@@ -34,7 +34,7 @@ private class SuspendedWrite<T> implements IContinuation<T> {
 	}
 
 	public function resume(v:T, error:Exception) {
-		if (context.get(CancellationToken.key).isCancellationRequested) {
+		if (context.get(CancellationToken).isCancellationRequested) {
 			continuation.failAsync(new CancellationException());
 		} else {
 			continuation.resume(v, error);
@@ -74,7 +74,7 @@ class SuspendedRead<T> implements IContinuation<T> {
 	}
 
 	public function resume(v:T, error:Exception) {
-		if (context.get(CancellationToken.key).isCancellationRequested) {
+		if (context.get(CancellationToken).isCancellationRequested) {
 			continuation.failAsync(new CancellationException());
 		} else {
 			continuation.resume(v, error);

--- a/std/hxcoro/task/CoroBaseTask.hx
+++ b/std/hxcoro/task/CoroBaseTask.hx
@@ -29,7 +29,7 @@ private class CoroTaskWith<T> implements ICoroNodeWith {
 
 	public function async<T>(lambda:NodeLambda<T>):ICoroTask<T> {
 		final child = new CoroTask(context, CoroTask.CoroChildStrategy);
-		context.get(Scheduler.key).schedule(0, () -> {
+		context.get(Scheduler).schedule(0, () -> {
 			child.runNodeLambda(lambda);
 		});
 		return child;
@@ -67,14 +67,14 @@ abstract class CoroBaseTask<T> extends AbstractTask<T> implements ICoroNode impl
 		Creates a new task using the provided `context`.
 	**/
 	public function new(context:Context, nodeStrategy:INodeStrategy, initialState:TaskState) {
-		super(context.get(CoroTask.key), initialState);
+		super(context.get(CoroTask), initialState);
 		initialContext = context;
 		this.nodeStrategy = nodeStrategy;
 	}
 
 	inline function get_context() {
 		if (context == null) {
-			context = initialContext.clone().with(this).add(CancellationToken.key, this);
+			context = initialContext.clone().with(this).add(CancellationToken, this);
 		}
 		return context;
 	}
@@ -131,7 +131,7 @@ abstract class CoroBaseTask<T> extends AbstractTask<T> implements ICoroNode impl
 	**/
 	public function async<T>(lambda:NodeLambda<T>):ICoroTask<T> {
 		final child = new CoroTask<T>(context, CoroTask.CoroChildStrategy);
-		context.get(Scheduler.key).schedule(0, () -> {
+		context.get(Scheduler).schedule(0, () -> {
 			child.runNodeLambda(lambda);
 		});
 		return child;

--- a/std/hxcoro/util/Convenience.hx
+++ b/std/hxcoro/util/Convenience.hx
@@ -66,6 +66,6 @@ class Convenience {
 		thread if the current dispatcher allows that.
 	**/
 	static public inline function resumeAsync<T>(cont:IContinuation<T>, result:T, error:Exception) {
-		cont.context.get(Scheduler.key).schedule(0, () -> cont.resume(result, error));
+		cont.context.get(Scheduler).schedule(0, () -> cont.resume(result, error));
 	}
 }

--- a/tests/misc/coroutines/src/components/TestCoroName.hx
+++ b/tests/misc/coroutines/src/components/TestCoroName.hx
@@ -6,7 +6,7 @@ class TestCoroName extends utest.Test {
 	@:coroutine
 	function logDebug() {
 		return suspend(cont -> {
-			cont.resume(cont.context.get(CoroName.key).name, null);
+			cont.resume(cont.context.get(CoroName).name, null);
 		});
 	}
 
@@ -30,7 +30,7 @@ class TestCoroName extends utest.Test {
 
 	function testChildrenNames() {
 		final result = CoroRun.with(new CoroName("Parent")).run(node -> {
-			final children = [for (i in 0...10) node.with(new CoroName('Name: $i')).async(node -> node.context.get(CoroName.key).name)];
+			final children = [for (i in 0...10) node.with(new CoroName('Name: $i')).async(node -> node.context.get(CoroName).name)];
 			[for (child in children) child.await()];
 		});
 		final expected = [for (i in 0...10) 'Name: $i'];

--- a/tests/misc/coroutines/src/issues/aidan/Issue126.hx
+++ b/tests/misc/coroutines/src/issues/aidan/Issue126.hx
@@ -17,7 +17,7 @@ class Junction {
 	function flushWaiters() {
 		while (!waiters.isEmpty()) {
 			final cont = waiters.pop();
-			cont.context.get(Scheduler.key).schedule(0, () -> cont.resume(null, null));
+			cont.context.get(Scheduler).schedule(0, () -> cont.resume(null, null));
 		}
 	}
 

--- a/tests/misc/coroutines/src/issues/aidan/Issue27.hx
+++ b/tests/misc/coroutines/src/issues/aidan/Issue27.hx
@@ -8,7 +8,7 @@ import haxe.coro.context.IElement;
 import hxcoro.task.ICoroTask;
 
 class DebugName implements IElement<DebugName> {
-	static public var key = new Key<DebugName>("DebugName");
+	static public final key = new Key<DebugName>("DebugName");
 
 	public var name:String;
 
@@ -29,14 +29,14 @@ class Issue27 extends utest.Test {
 	@:coroutine
 	function logDebug() {
 		return suspend(cont -> {
-			cont.resume(cont.context.get(DebugName.key).name, null);
+			cont.resume(cont.context.get(DebugName).name, null);
 		});
 	}
 
 	@:coroutine
 	function modifyDebug(name:String) {
 		suspend(cont -> {
-			cont.context.get(DebugName.key).name = name;
+			cont.context.get(DebugName).name = name;
 			cont.resume(null, null);
 		});
 	}

--- a/tests/misc/coroutines/src/structured/TestCancellingSuspend.hx
+++ b/tests/misc/coroutines/src/structured/TestCancellingSuspend.hx
@@ -109,7 +109,7 @@ class TestCancellingSuspend extends utest.Test {
 				cont.resume(null, null);
 			});
 
-			node.context.get(hxcoro.task.CoroTask.key).cancel();
+			node.context.get(hxcoro.task.CoroTask).cancel();
 
 			final actual = [];
 

--- a/tests/misc/coroutines/src/structured/TestTaskCancellation.hx
+++ b/tests/misc/coroutines/src/structured/TestTaskCancellation.hx
@@ -22,7 +22,7 @@ class TestTaskCancellation extends utest.Test {
 		final result    = [];
 		final scheduler = new VirtualTimeScheduler();
 		final task      = CoroRun.with(scheduler).create(node -> {
-			node.context.get(CoroTask.key).onCancellationRequested(new ResultPusherHandle(result));
+			node.context.get(CoroTask).onCancellationRequested(new ResultPusherHandle(result));
 
 			delay(1000);
 		});
@@ -42,7 +42,7 @@ class TestTaskCancellation extends utest.Test {
 		final result    = [];
 		final scheduler = new VirtualTimeScheduler();
 		final task      = CoroRun.with(scheduler).create(node -> {
-			handle = node.context.get(CoroTask.key).onCancellationRequested(new ResultPusherHandle(result));
+			handle = node.context.get(CoroTask).onCancellationRequested(new ResultPusherHandle(result));
 
 			delay(1000);
 		});


### PR DESCRIPTION
I think I found a way to do this in a type-safe way: by having an implicit cast from `Class<T>` to `Key<K>` with just the right constraints, we can use `context.get(Scheduler)` without the manual `.key` expression. This should generate the same code as before because everything is inlined and then accessed on the concrete class, just like a static.

I'm actually slightly surprised that it works like that, so there's a chance it actually doesn't.