### PR TITLE
Add IScheduleObject

### DIFF
--- a/std/haxe/coro/BaseContinuation.hx
+++ b/std/haxe/coro/BaseContinuation.hx
@@ -4,6 +4,7 @@ import haxe.coro.context.Context;
 import haxe.coro.context.Key;
 import haxe.coro.context.IElement;
 import haxe.coro.schedulers.Scheduler;
+import haxe.coro.schedulers.IScheduleObject;
 import haxe.CallStack.StackItem;
 import haxe.Exception;
 
@@ -21,7 +22,7 @@ class StackTraceManager implements IElement<StackTraceManager> {
 	}
 }
 
-abstract class BaseContinuation<T> extends SuspensionResult<T> implements IContinuation<T> implements IStackFrame {
+abstract class BaseContinuation<T> extends SuspensionResult<T> implements IContinuation<T> implements IStackFrame implements IScheduleObject {
     public final completion:IContinuation<Any>;
 
 	public var context(get, null):Context;
@@ -30,6 +31,7 @@ abstract class BaseContinuation<T> extends SuspensionResult<T> implements IConti
 
     public var recursing:Bool;
 
+	var resumeResult:Null<SuspensionResult<Any>>;
 	var stackItem:Null<StackItem>;
 	var startedException:Bool;
 	var scheduler:Scheduler;
@@ -56,19 +58,8 @@ abstract class BaseContinuation<T> extends SuspensionResult<T> implements IConti
         this.result = result;
         this.error  = error;
 		recursing = false;
-
-		final result = invokeResume();
-		final completion = completion; // avoid capturing `this` in the closure
-		scheduler.schedule(0, () -> {
-			switch (result.state) {
-				case Pending:
-					return;
-				case Returned:
-					completion.resume(result.result, null);
-				case Thrown:
-					completion.resume(null, result.error);
-			}
-		});
+		resumeResult = invokeResume();
+		scheduler.scheduleObject(this);
     }
 
     public function callerFrame():Null<IStackFrame> {
@@ -173,5 +164,16 @@ abstract class BaseContinuation<T> extends SuspensionResult<T> implements IConti
 
 	override function toString() {
 		return '[BaseContinuation ${state.toString()}, $result]';
+	}
+
+	public function onSchedule() {
+		switch (resumeResult.state) {
+			case Pending:
+				return;
+			case Returned:
+				completion.resume(resumeResult.result, null);
+			case Thrown:
+				completion.resume(null, resumeResult.error);
+		}
 	}
 }

--- a/std/haxe/coro/continuations/RacingContinuation.hx
+++ b/std/haxe/coro/continuations/RacingContinuation.hx
@@ -1,9 +1,10 @@
 package haxe.coro.continuations;
 
+import haxe.coro.schedulers.IScheduleObject;
 import haxe.coro.context.Context;
 import haxe.coro.schedulers.Scheduler;
 
-class RacingContinuation<T> extends SuspensionResult<T> implements IContinuation<T> {
+class RacingContinuation<T> extends SuspensionResult<T> implements IContinuation<T> implements IScheduleObject {
 	final inputCont:IContinuation<T>;
 
 	var mutex:Null<Mutex>;
@@ -24,25 +25,24 @@ class RacingContinuation<T> extends SuspensionResult<T> implements IContinuation
 
 	public function resume(result:T, error:Exception):Void {
 		// store in a local to avoid `this` capturing.
-		final inputCont = inputCont;
-		inline function resumeContinue(result:T, error:Exception) {
-			scheduler.schedule(0, () -> {
-				inputCont.resume(result, error);
-			});
+		inline function resumeContinue() {
+			this.result = result;
+			this.error = error;
+			scheduler.scheduleObject(this);
 		}
 
 		// Store mutex as stack value.
 		final mutex = mutex;
 		if (mutex == null) {
 			// If that's already null we're definitely done.
-			return resumeContinue(result, error);
+			return resumeContinue();
 		}
 		// Otherwise we take the mutex now. We know that the stack value isn't null, so that's safe.
 		mutex.acquire();
 		if (this.mutex == null) {
 			// The shared reference has become null in the meantime, so we're done.
 			mutex.release();
-			return resumeContinue(result, error);
+			return resumeContinue();
 		}
 		// At this point we own the mutex, so we're first. We can set the shared reference to null and release it.
 		this.mutex = null;
@@ -78,7 +78,7 @@ class RacingContinuation<T> extends SuspensionResult<T> implements IContinuation
 		state = Pending;
 	}
 
-	override function toString() {
-		return '[RacingContinuation ${state.toString()}, $result]';
+	public function onSchedule() {
+		inputCont.resume(result, error);
 	}
 }

--- a/std/haxe/coro/continuations/RacingContinuation.hx
+++ b/std/haxe/coro/continuations/RacingContinuation.hx
@@ -1,13 +1,20 @@
 package haxe.coro.continuations;
 
-import haxe.coro.schedulers.IScheduleObject;
+import hxcoro.concurrent.AtomicInt;
 import haxe.coro.context.Context;
 import haxe.coro.schedulers.Scheduler;
+import haxe.coro.schedulers.IScheduleObject;
+
+private enum abstract State(Int) to Int {
+	var Active;
+	var Resumed;
+	var Resolved;
+}
 
 class RacingContinuation<T> extends SuspensionResult<T> implements IContinuation<T> implements IScheduleObject {
 	final inputCont:IContinuation<T>;
 
-	var mutex:Null<Mutex>;
+	var resumeState:AtomicInt;
 
 	public var context(get, never):Context;
 
@@ -15,7 +22,7 @@ class RacingContinuation<T> extends SuspensionResult<T> implements IContinuation
 
 	public function new(inputCont:IContinuation<T>) {
 		this.inputCont = inputCont;
-		mutex = new Mutex();
+		resumeState = new AtomicInt(Active);
 		scheduler = context.get(Scheduler);
 	}
 
@@ -24,58 +31,23 @@ class RacingContinuation<T> extends SuspensionResult<T> implements IContinuation
 	}
 
 	public function resume(result:T, error:Exception):Void {
-		// store in a local to avoid `this` capturing.
-		inline function resumeContinue() {
-			this.result = result;
-			this.error = error;
-			scheduler.scheduleObject(this);
-		}
-
-		// Store mutex as stack value.
-		final mutex = mutex;
-		if (mutex == null) {
-			// If that's already null we're definitely done.
-			return resumeContinue();
-		}
-		// Otherwise we take the mutex now. We know that the stack value isn't null, so that's safe.
-		mutex.acquire();
-		if (this.mutex == null) {
-			// The shared reference has become null in the meantime, so we're done.
-			mutex.release();
-			return resumeContinue();
-		}
-		// At this point we own the mutex, so we're first. We can set the shared reference to null and release it.
-		this.mutex = null;
-		mutex.release();
 		this.result = result;
 		this.error = error;
+		if (resumeState.compareExchange(Active, Resumed) != Active) {
+			scheduler.scheduleObject(this);
+		}
 	}
 
-
 	public function resolve():Void {
-		// same logic as resume
-		final mutex = mutex;
-		if (mutex == null) {
+		if (resumeState.compareExchange(Active, Resolved) == Active) {
+			state = Pending;
+		} else {
 			if (error != null) {
 				state = Thrown;
 			} else {
 				state = Returned;
 			}
-			return;
 		}
-		mutex.acquire();
-		if (this.mutex == null) {
-			mutex.release();
-			if (error != null) {
-				state = Thrown;
-			} else {
-				state = Returned;
-			}
-			return;
-		}
-		this.mutex = null;
-		mutex.release();
-		state = Pending;
 	}
 
 	public function onSchedule() {

--- a/std/haxe/coro/schedulers/EventLoopScheduler.hx
+++ b/std/haxe/coro/schedulers/EventLoopScheduler.hx
@@ -45,11 +45,11 @@ private class NoOpHandle implements ISchedulerHandle {
 	public function close() {}
 }
 
-private class DoubleBuffer {
-	final a : Array<Lambda>;
-	final b : Array<Lambda>;
+private class DoubleBuffer<T> {
+	final a : Array<T>;
+	final b : Array<T>;
 
-	var current : Array<Lambda>;
+	var current : Array<T>;
 
 	public function new() {
 		a       = [];
@@ -66,7 +66,7 @@ private class DoubleBuffer {
 		return returning;
 	}
 
-	public function push(l : Lambda) {
+	public function push(l : T) {
 		current.push(l);
 	}
 
@@ -75,12 +75,24 @@ private class DoubleBuffer {
 	}
 }
 
+class FunctionScheduleObject implements IScheduleObject {
+	var func:() -> Void;
+
+	public function new(func:() -> Void) {
+		this.func = func;
+	}
+
+	public function onSchedule() {
+		func();
+	}
+}
+
 class EventLoopScheduler extends Scheduler {
 	var first : Null<ScheduledEvent>;
 	var last : Null<ScheduledEvent>;
 
 	final noOpHandle : NoOpHandle;
-	final zeroEvents : DoubleBuffer;
+	final zeroEvents : DoubleBuffer<IScheduleObject>;
 	final zeroMutex : Mutex;
 	final futureMutex : Mutex;
 	final closeClosure : CloseClosure;
@@ -102,7 +114,7 @@ class EventLoopScheduler extends Scheduler {
 			throw new ArgumentException("Time must be greater or equal to zero");
 		} else if (ms == 0) {
 			zeroMutex.acquire();
-			zeroEvents.push(func);
+			zeroEvents.push(new FunctionScheduleObject(func));
 			zeroMutex.release();
 			return noOpHandle;
 		}
@@ -159,18 +171,28 @@ class EventLoopScheduler extends Scheduler {
 		}
     }
 
+	public function scheduleObject(obj:IScheduleObject) {
+		zeroMutex.acquire();
+		zeroEvents.push(obj);
+		zeroMutex.release();
+	}
+
 	public function now() {
 		return Timer.milliseconds();
 	}
 
-	public function run() {
+	function runZeroEvents() {
 		zeroMutex.acquire();
 		final events = zeroEvents.flip();
 		// no need to hold onto the mutex because it's a double buffer and run itself is single-threaded
 		zeroMutex.release();
-		for (event in events) {
-			event();
+		for (obj in events) {
+			obj.onSchedule();
 		}
+	}
+
+	public function run() {
+		runZeroEvents();
 
 		final currentTime = now();
 

--- a/std/haxe/coro/schedulers/IScheduleObject.hx
+++ b/std/haxe/coro/schedulers/IScheduleObject.hx
@@ -1,0 +1,5 @@
+package haxe.coro.schedulers;
+
+interface IScheduleObject {
+	function onSchedule():Void;
+}

--- a/std/haxe/coro/schedulers/Scheduler.hx
+++ b/std/haxe/coro/schedulers/Scheduler.hx
@@ -10,6 +10,8 @@ abstract class Scheduler implements IElement<Scheduler> {
 
 	public abstract function schedule(ms:Int64, func:() -> Void):ISchedulerHandle;
 
+	public abstract function scheduleObject(obj:IScheduleObject):Void;
+
 	public abstract function now():Int64;
 
 	public function getKey() {

--- a/std/haxe/coro/schedulers/VirtualTimeScheduler.hx
+++ b/std/haxe/coro/schedulers/VirtualTimeScheduler.hx
@@ -36,9 +36,7 @@ class VirtualTimeScheduler extends EventLoopScheduler {
 
 	function virtualRun(endTime : Int64) {
 		while (true) {
-			for (event in zeroEvents.flip()) {
-				event();
-			}
+			runZeroEvents();
 
 			while (true) {
 				if (first == null) {

--- a/std/hxcoro/Coro.hx
+++ b/std/hxcoro/Coro.hx
@@ -26,10 +26,10 @@ class Coro {
 	 * The `ICancellableContinuation` passed to the function allows registering a callback which is invoked on cancellation
 	 * allowing the easy cleanup of resources.
 	 */
-	@:coroutine public static function suspendCancellable<T>(func:ICancellableContinuation<T>->Void) {
-		return suspend(cont -> {
-			func(new CancellingContinuation(cont));
-		});
+	@:coroutine @:coroutine.transformed public static function suspendCancellable<T>(func:ICancellableContinuation<T>->Void, completion:IContinuation<T>):T {
+		var safe = new CancellingContinuation(completion);
+		func(safe);
+		return cast safe;
 	}
 
 	static function cancellationRequested(cont:IContinuation<Any>) {

--- a/std/hxcoro/Coro.hx
+++ b/std/hxcoro/Coro.hx
@@ -36,20 +36,22 @@ class Coro {
 		return cont.context.get(CancellationToken)?.isCancellationRequested;
 	}
 
-	@:coroutine @:coroutine.nothrow public static function delay(ms:Int):Void {
-		suspendCancellable(cont -> {
-			final handle = cont.context.get(Scheduler).schedule(ms, () -> {
-				cont.callSync();
-			});
-
-			cont.onCancellationRequested = () -> {
-				handle.close();
-			}
+	static function delayImpl<T>(ms:Int, cont:ICancellableContinuation<T>) {
+		final handle = cont.context.get(Scheduler).schedule(ms, () -> {
+			cont.callSync();
 		});
+
+		cont.onCancellationRequested = () -> {
+			handle.close();
+		}
+	}
+
+	@:coroutine @:coroutine.nothrow public static function delay(ms:Int):Void {
+		suspendCancellable(cont -> delayImpl(ms, cont));
 	}
 
 	@:coroutine @:coroutine.nothrow public static function yield():Void {
-		delay(0);
+		suspendCancellable(cont -> delayImpl(0, cont));
 	}
 
 	@:coroutine static public function scope<T>(lambda:NodeLambda<T>):T {

--- a/std/hxcoro/continuations/CancellingContinuation.hx
+++ b/std/hxcoro/continuations/CancellingContinuation.hx
@@ -1,5 +1,6 @@
 package hxcoro.continuations;
 
+import haxe.coro.SuspensionResult;
 import haxe.coro.schedulers.IScheduleObject;
 import hxcoro.concurrent.AtomicInt;
 import haxe.Exception;
@@ -18,17 +19,14 @@ private enum abstract State(Int) to Int {
 	var Cancelled;
 }
 
-class CancellingContinuation<T> implements ICancellableContinuation<T> implements ICancellationCallback implements IScheduleObject {
-	final state : AtomicInt;
+class CancellingContinuation<T> extends SuspensionResult<T> implements ICancellableContinuation<T> implements ICancellationCallback implements IScheduleObject {
+	final resumeState : AtomicInt;
 
 	final cont : IContinuation<T>;
 
 	final handle : ICancellationHandle;
 
 	public var context (get, never) : Context;
-
-	var result:T;
-	var error:Exception;
 
 	function get_context() {
 		return cont.context;
@@ -52,9 +50,10 @@ class CancellingContinuation<T> implements ICancellableContinuation<T> implement
 	}
 
 	public function new(cont) {
-		this.state  = new AtomicInt(Active);
+		this.resumeState  = new AtomicInt(Active);
 		this.cont   = cont;
 		this.handle = this.cont.context.get(CancellationToken).onCancellationRequested(this);
+		this.state  = Pending;
 	}
 
 	public function resume(result:T, error:Exception) {
@@ -66,7 +65,7 @@ class CancellingContinuation<T> implements ICancellableContinuation<T> implement
 	public function onCancellation() {
 		handle?.close();
 
-		if (state.compareExchange(Active, Cancelled) == Active) {
+		if (resumeState.compareExchange(Active, Cancelled) == Active) {
 			if (null != onCancellationRequested) {
 				onCancellationRequested();
 			}
@@ -76,7 +75,7 @@ class CancellingContinuation<T> implements ICancellableContinuation<T> implement
 	}
 
 	public function onSchedule() {
-		if (state.compareExchange(Active, Resumed) == Active) {
+		if (resumeState.compareExchange(Active, Resumed) == Active) {
 			handle.close();
 			cont.resume(result, error);
 		} else {

--- a/std/hxcoro/continuations/CancellingContinuation.hx
+++ b/std/hxcoro/continuations/CancellingContinuation.hx
@@ -1,5 +1,6 @@
 package hxcoro.continuations;
 
+import haxe.coro.schedulers.IScheduleObject;
 import hxcoro.concurrent.AtomicInt;
 import haxe.Exception;
 import haxe.exceptions.CancellationException;
@@ -17,7 +18,7 @@ private enum abstract State(Int) to Int {
 	var Cancelled;
 }
 
-class CancellingContinuation<T> implements ICancellableContinuation<T> implements ICancellationCallback {
+class CancellingContinuation<T> implements ICancellableContinuation<T> implements ICancellationCallback implements IScheduleObject {
 	final state : AtomicInt;
 
 	final cont : IContinuation<T>;
@@ -25,6 +26,9 @@ class CancellingContinuation<T> implements ICancellableContinuation<T> implement
 	final handle : ICancellationHandle;
 
 	public var context (get, never) : Context;
+
+	var result:T;
+	var error:Exception;
 
 	function get_context() {
 		return cont.context;
@@ -54,14 +58,9 @@ class CancellingContinuation<T> implements ICancellableContinuation<T> implement
 	}
 
 	public function resume(result:T, error:Exception) {
-		context.get(Scheduler).schedule(0, () -> {
-			if (state.compareExchange(Active, Resumed) == Active) {
-				handle.close();
-				cont.resume(result, error);
-			} else {
-				cont.failAsync(new CancellationException());
-			}
-		});
+		this.result = result;
+		this.error = error;
+		context.get(Scheduler).scheduleObject(this);
 	}
 
 	public function onCancellation() {
@@ -73,6 +72,15 @@ class CancellingContinuation<T> implements ICancellableContinuation<T> implement
 			}
 
 			resume(null, null);
+		}
+	}
+
+	public function onSchedule() {
+		if (state.compareExchange(Active, Resumed) == Active) {
+			handle.close();
+			cont.resume(result, error);
+		} else {
+			cont.failAsync(new CancellationException());
 		}
 	}
 }

--- a/std/hxcoro/continuations/CancellingContinuation.hx
+++ b/std/hxcoro/continuations/CancellingContinuation.hx
@@ -59,7 +59,13 @@ class CancellingContinuation<T> extends SuspensionResult<T> implements ICancella
 	public function resume(result:T, error:Exception) {
 		this.result = result;
 		this.error = error;
-		context.get(Scheduler).scheduleObject(this);
+		if (resumeState.compareExchange(Active, Resumed) == Active) {
+			handle.close();
+			context.get(Scheduler).scheduleObject(this);
+		} else {
+			cont.failAsync(new CancellationException());
+		}
+
 	}
 
 	public function onCancellation() {
@@ -70,16 +76,11 @@ class CancellingContinuation<T> extends SuspensionResult<T> implements ICancella
 				onCancellationRequested();
 			}
 
-			resume(null, null);
+			cont.failAsync(new CancellationException());
 		}
 	}
 
 	public function onSchedule() {
-		if (resumeState.compareExchange(Active, Resumed) == Active) {
-			handle.close();
-			cont.resume(result, error);
-		} else {
-			cont.failAsync(new CancellationException());
-		}
+		cont.resume(result, error);
 	}
 }

--- a/std/hxcoro/task/CoroBaseTask.hx
+++ b/std/hxcoro/task/CoroBaseTask.hx
@@ -1,5 +1,6 @@
 package hxcoro.task;
 
+import hxcoro.task.CoroTask;
 import hxcoro.task.node.INodeStrategy;
 import hxcoro.task.ICoroTask;
 import hxcoro.task.AbstractTask;
@@ -28,10 +29,8 @@ private class CoroTaskWith<T> implements ICoroNodeWith {
 	}
 
 	public function async<T>(lambda:NodeLambda<T>):ICoroTask<T> {
-		final child = new CoroTask(context, CoroTask.CoroChildStrategy);
-		context.get(Scheduler).schedule(0, () -> {
-			child.runNodeLambda(lambda);
-		});
+		final child = new CoroTaskWithLambda(context, lambda, CoroTask.CoroChildStrategy);
+		context.get(Scheduler).scheduleObject(child);
 		return child;
 	}
 
@@ -130,10 +129,8 @@ abstract class CoroBaseTask<T> extends AbstractTask<T> implements ICoroNode impl
 		Creates a child task to execute `lambda` and starts it automatically.
 	**/
 	public function async<T>(lambda:NodeLambda<T>):ICoroTask<T> {
-		final child = new CoroTask<T>(context, CoroTask.CoroChildStrategy);
-		context.get(Scheduler).schedule(0, () -> {
-			child.runNodeLambda(lambda);
-		});
+		final child = new CoroTaskWithLambda<T>(context, lambda, CoroTask.CoroChildStrategy);
+		context.get(Scheduler).scheduleObject(child);
 		return child;
 	}
 

--- a/std/hxcoro/task/CoroTask.hx
+++ b/std/hxcoro/task/CoroTask.hx
@@ -8,6 +8,7 @@ import hxcoro.task.AbstractTask;
 import haxe.coro.IContinuation;
 import haxe.coro.context.Key;
 import haxe.coro.context.Context;
+import haxe.coro.schedulers.IScheduleObject;
 import haxe.Exception;
 
 class CoroTask<T> extends CoroBaseTask<T> implements IContinuation<T> {
@@ -67,5 +68,21 @@ class CoroTask<T> extends CoroBaseTask<T> implements IContinuation<T> {
 			return;
 		}
 		super.checkCompletion();
+	}
+}
+
+class CoroTaskWithLambda<T> extends CoroTask<T> implements IScheduleObject {
+	final lambda:NodeLambda<T>;
+
+	/**
+		Creates a new task using the provided `context` in order to execute `lambda`.
+	**/
+	public function new(context:Context, lambda:NodeLambda<T>, nodeStrategy:INodeStrategy) {
+		super(context, nodeStrategy);
+		this.lambda = lambda;
+	}
+
+	public function onSchedule() {
+		runNodeLambda(lambda);
 	}
 }

--- a/tests/misc/coroutines/src/TestGenerator.hx
+++ b/tests/misc/coroutines/src/TestGenerator.hx
@@ -1,3 +1,4 @@
+import haxe.coro.schedulers.IScheduleObject;
 import haxe.Int64;
 import haxe.coro.schedulers.Scheduler;
 import hxcoro.task.CoroTask;
@@ -17,6 +18,10 @@ class ImmediateScheduler extends Scheduler {
 		}
 		f();
 		return null;
+	}
+
+	public function scheduleObject(obj:IScheduleObject) {
+		obj.onSchedule();
 	}
 
 	public function now() {


### PR DESCRIPTION
As my war against closures continues, this adds a new function to the scheduler that allows scheduling `IScheduleObject` instances without delay. We have a lot of small objects that schedule a closure to be called asynchronously, in which case it makes sense to instead schedule the objects themselves to avoid the closure allocation.

This now comes with the added benefit of avoiding the Int64 allocation on targets that don't natively support it. Numbers look ok:

100k | kt_coro | IScheduleObject | scheduler_state | +suspendCancellable
--- | --- | --- | --- | ---
neko | 107.389 | 101.435 | 115.645 | 25.528
python | 34.672 | 28.449 | 36.087 | 20.750
eval | 20.219 | 17.761 | 21.360 | 13.401
hl | 10.020 | 10.041 | 11.006 | 7.427
cpp | 2.769 | 2.788 | 2.838 | 2.242
js | 2.091 | 1.975 | 2.079 | 1.907
jvm | 1.424 | 1.401 | 1.411 | 1.305

HL is a disappointment here, I guess that the overhead from the interface call offsets the reduced GC activity. But this isn't so much about run-time anyway as it is about memory footprint:

<img width="1771" alt="jprofiler_9f93aEHnFs" src="https://github.com/user-attachments/assets/fa7a5c8e-cede-4b3b-b507-fcacde39fa42" />

We traded 8M continuation closures + 2M async closures for 2M `FunctionScheduleObject`, which is the wrapper type for where we're still calling `schedule(0, ...)`. It should be possible to reduce this further by identifying these places. The new `resumeAsync` convenience functions and its siblings might actually get in the way of that a little.

Memory consumption goes from 1.95GB with 5.7M allocated objects to 1.77GB with 4.3M allocated objects. 