### PR TITLE
Scheduler state

### DIFF
--- a/std/haxe/coro/BaseContinuation.hx
+++ b/std/haxe/coro/BaseContinuation.hx
@@ -59,7 +59,7 @@ abstract class BaseContinuation<T> extends SuspensionResult<T> implements IConti
 
 		final result = invokeResume();
 		final completion = completion; // avoid capturing `this` in the closure
-		scheduler.schedule(0, () -> {
+		scheduler.schedule(0, this, (_, self) -> {
 			switch (result.state) {
 				case Pending:
 					return;

--- a/std/haxe/coro/BaseContinuation.hx
+++ b/std/haxe/coro/BaseContinuation.hx
@@ -7,6 +7,8 @@ import haxe.coro.schedulers.Scheduler;
 import haxe.CallStack.StackItem;
 import haxe.Exception;
 
+using hxcoro.util.Convenience;
+
 class StackTraceManager implements IElement<StackTraceManager> {
 	public static final key = new Key<StackTraceManager>('StackTraceManager');
 
@@ -33,6 +35,7 @@ abstract class BaseContinuation<T> extends SuspensionResult<T> implements IConti
 	var stackItem:Null<StackItem>;
 	var startedException:Bool;
 	var scheduler:Scheduler;
+	var resumeSuspension:SuspensionResult<T>;
 
     function new(completion:IContinuation<Any>, initialLabel:Int) {
         this.completion = completion;
@@ -43,6 +46,7 @@ abstract class BaseContinuation<T> extends SuspensionResult<T> implements IConti
         recursing  = false;
 		startedException = false;
 		scheduler = completion.context.get(Scheduler);
+		resumeSuspension = null;
     }
 
 	inline function get_context() {
@@ -56,17 +60,16 @@ abstract class BaseContinuation<T> extends SuspensionResult<T> implements IConti
         this.result = result;
         this.error  = error;
 		recursing = false;
+		resumeSuspension = invokeResume();
 
-		final result = invokeResume();
-		final completion = completion; // avoid capturing `this` in the closure
-		scheduler.schedule(0, this, (_, self) -> {
-			switch (result.state) {
+		scheduler.scheduleFunction(this, (self:BaseContinuation<T>) -> {
+			switch (self.resumeSuspension.state) {
 				case Pending:
 					return;
 				case Returned:
-					completion.resume(result.result, null);
+					self.completion.resume(self.resumeSuspension.result, null);
 				case Thrown:
-					completion.resume(null, result.error);
+					self.completion.resume(null, self.resumeSuspension.error);
 			}
 		});
     }

--- a/std/haxe/coro/continuations/RacingContinuation.hx
+++ b/std/haxe/coro/continuations/RacingContinuation.hx
@@ -3,6 +3,8 @@ package haxe.coro.continuations;
 import haxe.coro.context.Context;
 import haxe.coro.schedulers.Scheduler;
 
+using hxcoro.util.Convenience;
+
 class RacingContinuation<T> extends SuspensionResult<T> implements IContinuation<T> {
 	final inputCont:IContinuation<T>;
 
@@ -28,7 +30,7 @@ class RacingContinuation<T> extends SuspensionResult<T> implements IContinuation
 		this.error = error;
 
 		inline function resumeContinue(result:T, error:Exception) {
-			scheduler.schedule(0, this, (_, self) -> {
+			scheduler.scheduleFunction(this, self -> {
 				self.inputCont.resume(self.result, self.error);
 			});
 		}

--- a/std/haxe/coro/continuations/RacingContinuation.hx
+++ b/std/haxe/coro/continuations/RacingContinuation.hx
@@ -23,11 +23,13 @@ class RacingContinuation<T> extends SuspensionResult<T> implements IContinuation
 	}
 
 	public function resume(result:T, error:Exception):Void {
-		// store in a local to avoid `this` capturing.
-		final inputCont = inputCont;
+
+		this.result = result;
+		this.error = error;
+
 		inline function resumeContinue(result:T, error:Exception) {
-			scheduler.schedule(0, () -> {
-				inputCont.resume(result, error);
+			scheduler.schedule(0, this, (_, self) -> {
+				self.inputCont.resume(self.result, self.error);
 			});
 		}
 
@@ -47,8 +49,6 @@ class RacingContinuation<T> extends SuspensionResult<T> implements IContinuation
 		// At this point we own the mutex, so we're first. We can set the shared reference to null and release it.
 		this.mutex = null;
 		mutex.release();
-		this.result = result;
-		this.error = error;
 	}
 
 

--- a/std/haxe/coro/schedulers/EventLoopScheduler.hx
+++ b/std/haxe/coro/schedulers/EventLoopScheduler.hx
@@ -2,19 +2,21 @@ package haxe.coro.schedulers;
 
 import haxe.exceptions.ArgumentException;
 
-private typedef Lambda = ()->Void;
+private typedef Lambda<T> = (scheduler:Scheduler, state:T)->Void;
 private typedef CloseClosure = (handle:ISchedulerHandle)->Void;
 
-private class ScheduledEvent implements ISchedulerHandle {
+private class ScheduledEvent<T> implements ISchedulerHandle {
 	final closure : CloseClosure;
-	final func : Lambda;
+	final func : Lambda<T>;
+	final state : T;
 	var closed : Bool;
 	public final runTime : Int64;
-	public var next : Null<ScheduledEvent>;
-	public var previous : Null<ScheduledEvent>;
+	public var next : Null<ScheduledEvent<Any>>;
+	public var previous : Null<ScheduledEvent<Any>>;
 
-	public function new(closure, func, runTime) {
+	public function new(closure, func, state, runTime) {
 		this.closure = closure;
+		this.state   = state;
 		this.func    = func;
 		this.runTime = runTime;
 
@@ -23,8 +25,8 @@ private class ScheduledEvent implements ISchedulerHandle {
 		previous = null;
 	}
 
-	public inline function run() {
-		func();
+	public inline function run(scheduler:Scheduler) {
+		func(scheduler, state);
 
 		closed = true;
 	}
@@ -40,16 +42,30 @@ private class ScheduledEvent implements ISchedulerHandle {
 	}
 }
 
+private class ZeroEvent<T> {
+	final func : Lambda<T>;
+	final state : T;
+
+	public function new(func:Lambda<T>, state:T) {
+		this.func = func;
+		this.state = state;
+	}
+
+	public inline function run(scheduler:Scheduler) {
+		func(scheduler, state);
+	}
+}
+
 private class NoOpHandle implements ISchedulerHandle {
 	public function new() {}
 	public function close() {}
 }
 
 private class DoubleBuffer {
-	final a : Array<Lambda>;
-	final b : Array<Lambda>;
+	final a : Array<ZeroEvent<Any>>;
+	final b : Array<ZeroEvent<Any>>;
 
-	var current : Array<Lambda>;
+	var current : Array<ZeroEvent<Any>>;
 
 	public function new() {
 		a       = [];
@@ -66,8 +82,8 @@ private class DoubleBuffer {
 		return returning;
 	}
 
-	public function push(l : Lambda) {
-		current.push(l);
+	public function push<T>(l : Lambda<T>, state : T) {
+		current.push(new ZeroEvent(l, state));
 	}
 
 	public function empty() {
@@ -76,8 +92,8 @@ private class DoubleBuffer {
 }
 
 class EventLoopScheduler extends Scheduler {
-	var first : Null<ScheduledEvent>;
-	var last : Null<ScheduledEvent>;
+	var first : Null<ScheduledEvent<Any>>;
+	var last : Null<ScheduledEvent<Any>>;
 
 	final noOpHandle : NoOpHandle;
 	final zeroEvents : DoubleBuffer;
@@ -97,17 +113,17 @@ class EventLoopScheduler extends Scheduler {
 		closeClosure = close;
 	}
 
-    public function schedule(ms:Int64, func:()->Void):ISchedulerHandle {
+    public function schedule<T>(ms:Int64, state:T, func:(scheduler:Scheduler, state:T)->Void):ISchedulerHandle {
 		if (ms < 0) {
 			throw new ArgumentException("Time must be greater or equal to zero");
 		} else if (ms == 0) {
 			zeroMutex.acquire();
-			zeroEvents.push(func);
+			zeroEvents.push(func, state);
 			zeroMutex.release();
 			return noOpHandle;
 		}
 
-		final event = new ScheduledEvent(closeClosure, func, now() + ms);
+		final event = new ScheduledEvent(closeClosure, func, state, now() + ms);
 
 		futureMutex.acquire();
 		if (first == null) {
@@ -169,7 +185,7 @@ class EventLoopScheduler extends Scheduler {
 		// no need to hold onto the mutex because it's a double buffer and run itself is single-threaded
 		zeroMutex.release();
 		for (event in events) {
-			event();
+			event.run(this);
 		}
 
 		final currentTime = now();
@@ -187,7 +203,7 @@ class EventLoopScheduler extends Scheduler {
 					first.previous = null;
 				}
 				futureMutex.release();
-				toRun.run();
+				toRun.run(this);
 				futureMutex.acquire();
 			} else {
 				break;

--- a/std/haxe/coro/schedulers/Scheduler.hx
+++ b/std/haxe/coro/schedulers/Scheduler.hx
@@ -8,7 +8,7 @@ abstract class Scheduler implements IElement<Scheduler> {
 
 	function new() {}
 
-	public abstract function schedule(ms:Int64, func:() -> Void):ISchedulerHandle;
+	public abstract function schedule<T>(ms:Int64, state:T, func:(scheduler:Scheduler, state:T) -> Void):ISchedulerHandle;
 
 	public abstract function now():Int64;
 

--- a/std/haxe/coro/schedulers/VirtualTimeScheduler.hx
+++ b/std/haxe/coro/schedulers/VirtualTimeScheduler.hx
@@ -37,7 +37,7 @@ class VirtualTimeScheduler extends EventLoopScheduler {
 	function virtualRun(endTime : Int64) {
 		while (true) {
 			for (event in zeroEvents.flip()) {
-				event();
+				event.run(this);
 			}
 
 			while (true) {
@@ -52,7 +52,7 @@ class VirtualTimeScheduler extends EventLoopScheduler {
 					if (first != null) {
 						first.previous = null;
 					}
-					toRun.run();
+					toRun.run(this);
 				} else {
 					break;
 				}

--- a/std/hxcoro/Coro.hx
+++ b/std/hxcoro/Coro.hx
@@ -38,7 +38,7 @@ class Coro {
 
 	@:coroutine @:coroutine.nothrow public static function delay(ms:Int):Void {
 		suspendCancellable(cont -> {
-			final handle = cont.context.get(Scheduler).schedule(ms, cont, (_, c) -> {
+			final handle = cont.context.get(Scheduler).scheduleFunction(ms, cont, (_, c) -> {
 				c.callSync();
 			});
 
@@ -49,10 +49,14 @@ class Coro {
 	}
 
 	@:coroutine @:coroutine.nothrow public static function yield():Void {
-		suspend(cont -> {
-			cont.context.get(Scheduler).schedule(0, cont, (_, c) -> {
-				c.failSync(cancellationRequested(c) ? new CancellationException() : null);
+		suspendCancellable(cont -> {
+			final handle = cont.context.get(Scheduler).scheduleFunction(cont, c -> {
+				c.callSync();
 			});
+			
+			cont.onCancellationRequested = () -> {
+				handle.close();
+			}
 		});
 	}
 
@@ -103,7 +107,7 @@ class Coro {
 
 			final context = cont.context;
 			final scope = new CoroTask(context, CoroTask.CoroScopeStrategy);
-			final handle = context.get(Scheduler).schedule(ms, scope, (_, s) -> {
+			final handle = context.get(Scheduler).scheduleFunction(ms, scope, s -> {
 				s.cancel(new TimeoutException());
 			});
 

--- a/std/hxcoro/Coro.hx
+++ b/std/hxcoro/Coro.hx
@@ -38,8 +38,8 @@ class Coro {
 
 	@:coroutine @:coroutine.nothrow public static function delay(ms:Int):Void {
 		suspendCancellable(cont -> {
-			final handle = cont.context.get(Scheduler).schedule(ms, () -> {
-				cont.callSync();
+			final handle = cont.context.get(Scheduler).schedule(ms, cont, (_, c) -> {
+				c.callSync();
 			});
 
 			cont.onCancellationRequested = () -> {
@@ -50,8 +50,8 @@ class Coro {
 
 	@:coroutine @:coroutine.nothrow public static function yield():Void {
 		suspend(cont -> {
-			cont.context.get(Scheduler).schedule(0, () -> {
-				cont.failSync(cancellationRequested(cont) ? new CancellationException() : null);
+			cont.context.get(Scheduler).schedule(0, cont, (_, c) -> {
+				c.failSync(cancellationRequested(c) ? new CancellationException() : null);
 			});
 		});
 	}
@@ -103,8 +103,8 @@ class Coro {
 
 			final context = cont.context;
 			final scope = new CoroTask(context, CoroTask.CoroScopeStrategy);
-			final handle = context.get(Scheduler).schedule(ms, () -> {
-				scope.cancel(new TimeoutException());
+			final handle = context.get(Scheduler).schedule(ms, scope, (_, s) -> {
+				s.cancel(new TimeoutException());
 			});
 
 			scope.runNodeLambda(lambda);

--- a/std/hxcoro/continuations/CancellingContinuation.hx
+++ b/std/hxcoro/continuations/CancellingContinuation.hx
@@ -54,12 +54,12 @@ class CancellingContinuation<T> implements ICancellableContinuation<T> implement
 	}
 
 	public function resume(result:T, error:Exception) {
-		context.get(Scheduler).schedule(0, () -> {
-			if (state.compareExchange(Active, Resumed) == Active) {
-				handle.close();
-				cont.resume(result, error);
+		context.get(Scheduler).schedule(0, this, (_, self) -> {
+			if (self.state.compareExchange(Active, Resumed) == Active) {
+				self.handle.close();
+				self.cont.resume(result, error);
 			} else {
-				cont.failAsync(new CancellationException());
+				self.cont.failAsync(new CancellationException());
 			}
 		});
 	}

--- a/std/hxcoro/continuations/CancellingContinuation.hx
+++ b/std/hxcoro/continuations/CancellingContinuation.hx
@@ -24,6 +24,10 @@ class CancellingContinuation<T> implements ICancellableContinuation<T> implement
 
 	final handle : ICancellationHandle;
 
+	var result : T;
+
+	var error : Exception;
+
 	public var context (get, never) : Context;
 
 	function get_context() {
@@ -54,10 +58,13 @@ class CancellingContinuation<T> implements ICancellableContinuation<T> implement
 	}
 
 	public function resume(result:T, error:Exception) {
-		context.get(Scheduler).schedule(0, this, (_, self) -> {
+		this.result = result;
+		this.error  = error;
+
+		context.get(Scheduler).scheduleFunction(this, self -> {
 			if (self.state.compareExchange(Active, Resumed) == Active) {
 				self.handle.close();
-				self.cont.resume(result, error);
+				self.cont.resume(self.result, self.error);
 			} else {
 				self.cont.failAsync(new CancellationException());
 			}

--- a/std/hxcoro/task/CoroBaseTask.hx
+++ b/std/hxcoro/task/CoroBaseTask.hx
@@ -29,7 +29,7 @@ private class CoroTaskWith<T> implements ICoroNodeWith {
 
 	public function async<T>(lambda:NodeLambda<T>):ICoroTask<T> {
 		final child = new CoroTask(context, CoroTask.CoroChildStrategy);
-		context.get(Scheduler).schedule(0, () -> {
+		context.get(Scheduler).scheduleFunction(() -> {
 			child.runNodeLambda(lambda);
 		});
 		return child;
@@ -131,7 +131,7 @@ abstract class CoroBaseTask<T> extends AbstractTask<T> implements ICoroNode impl
 	**/
 	public function async<T>(lambda:NodeLambda<T>):ICoroTask<T> {
 		final child = new CoroTask<T>(context, CoroTask.CoroChildStrategy);
-		context.get(Scheduler).schedule(0, () -> {
+		context.get(Scheduler).scheduleFunction(() -> {
 			child.runNodeLambda(lambda);
 		});
 		return child;

--- a/std/hxcoro/util/Convenience.hx
+++ b/std/hxcoro/util/Convenience.hx
@@ -71,34 +71,77 @@ class Convenience {
 		cont.context.get(Scheduler).scheduleFunction(() -> cont.resume(result, error));
 	}
 
+	/**
+	 * Schedules a function to be executed as soon as possible
+	 * @param scheduler Scheduler to execute the function on.
+	 * @param func Function to execute.
+	 * @return Handle which provides a best effort way to cancel the execution of the scheduled function.
+	 */
 	public static extern inline overload function scheduleFunction(scheduler : Scheduler, func : ()->Void) : ISchedulerHandle {
 		return scheduler.schedule(0, null, (_, _) -> {
 			func();
 		});
 	}
 
+	/**
+	 * Schedules a function to be executed as soon as possible
+	 * @param scheduler Scheduler to execute the function on.
+	 * @param state Object to be passed into the function when executed.
+	 * @param func Function to execute.
+	 * @return Handle which provides a best effort way to cancel the execution of the scheduled function.
+	 */
 	public static extern inline overload function scheduleFunction<T>(scheduler : Scheduler, state : T, func : (state : T)->Void) : ISchedulerHandle {
 		return scheduler.schedule(0, state, (_, s) -> {
 			func(s);
 		});
 	}
 
+	/**
+	 * Schedules a function to be executed as soon as possible
+	 * @param scheduler Scheduler to execute the function on.
+	 * @param state Object to be passed into the function when executed.
+	 * @param func Function to execute.
+	 * @return Handle which provides a best effort way to cancel the execution of the scheduled function.
+	 */
 	public static extern inline overload function scheduleFunction<T>(scheduler : Scheduler, state : T, func : (scheduler : Scheduler, state : T)->Void) : ISchedulerHandle {
 		return scheduler.schedule(0, state, func);
 	}
 
+	/**
+	 * Schedules a function to be executed after the specified time has passed.
+	 * @param scheduler Scheduler to execute the function on.
+	 * @param ms The relative time in milliseconds after which to execute the function.
+	 * @param func Function to execute.
+	 * @return Handle which provides a best effort way to cancel the execution of the scheduled function.
+	 */
 	public static extern inline overload function scheduleFunction(scheduler : Scheduler, ms : Int64, func : ()->Void) : ISchedulerHandle {
 		return scheduler.schedule(ms, null, (_, _) -> {
 			func();
 		});
 	}
 
+	/**
+	 * Schedules a function to be executed after the specified time has passed.
+	 * @param scheduler Scheduler to execute the function on.
+	 * @param ms The relative time in milliseconds after which to execute the function.
+	 * @param state Object to be passed into the function when executed.
+	 * @param func Function to execute.
+	 * @return Handle which provides a best effort way to cancel the execution of the scheduled function.
+	 */
 	public static extern inline overload function scheduleFunction<T>(scheduler : Scheduler, ms : Int64, state : T, func : (state : T)->Void) : ISchedulerHandle {
 		return scheduler.schedule(ms, state, (_, s) -> {
 			func(s);
 		});
 	}
 
+	/**
+	 * Schedules a function to be executed after the specified time has passed.
+	 * @param scheduler Scheduler to execute the function on.
+	 * @param ms The relative time in milliseconds after which to execute the function.
+	 * @param state Object to be passed into the function when executed.
+	 * @param func Function to execute.
+	 * @return Handle which provides a best effort way to cancel the execution of the scheduled function.
+	 */
 	public static extern inline overload function scheduleFunction<T>(scheduler : Scheduler, ms : Int64, state : T, func : (scheduler : Scheduler, state : T)->Void) : ISchedulerHandle {
 		return scheduler.schedule(ms, state, func);
 	}

--- a/std/hxcoro/util/Convenience.hx
+++ b/std/hxcoro/util/Convenience.hx
@@ -1,5 +1,7 @@
 package hxcoro.util;
 
+import haxe.coro.schedulers.ISchedulerHandle;
+import haxe.Int64;
 import haxe.coro.schedulers.Scheduler;
 import haxe.Exception;
 import haxe.coro.IContinuation;
@@ -66,6 +68,38 @@ class Convenience {
 		thread if the current dispatcher allows that.
 	**/
 	static public inline function resumeAsync<T>(cont:IContinuation<T>, result:T, error:Exception) {
-		cont.context.get(Scheduler).schedule(0, () -> cont.resume(result, error));
+		cont.context.get(Scheduler).scheduleFunction(() -> cont.resume(result, error));
+	}
+
+	public static extern inline overload function scheduleFunction(scheduler : Scheduler, func : ()->Void) : ISchedulerHandle {
+		return scheduler.schedule(0, null, (_, _) -> {
+			func();
+		});
+	}
+
+	public static extern inline overload function scheduleFunction<T>(scheduler : Scheduler, state : T, func : (state : T)->Void) : ISchedulerHandle {
+		return scheduler.schedule(0, state, (_, s) -> {
+			func(s);
+		});
+	}
+
+	public static extern inline overload function scheduleFunction<T>(scheduler : Scheduler, state : T, func : (scheduler : Scheduler, state : T)->Void) : ISchedulerHandle {
+		return scheduler.schedule(0, state, func);
+	}
+
+	public static extern inline overload function scheduleFunction(scheduler : Scheduler, ms : Int64, func : ()->Void) : ISchedulerHandle {
+		return scheduler.schedule(ms, null, (_, _) -> {
+			func();
+		});
+	}
+
+	public static extern inline overload function scheduleFunction<T>(scheduler : Scheduler, ms : Int64, state : T, func : (state : T)->Void) : ISchedulerHandle {
+		return scheduler.schedule(ms, state, (_, s) -> {
+			func(s);
+		});
+	}
+
+	public static extern inline overload function scheduleFunction<T>(scheduler : Scheduler, ms : Int64, state : T, func : (scheduler : Scheduler, state : T)->Void) : ISchedulerHandle {
+		return scheduler.schedule(ms, state, func);
 	}
 }

--- a/tests/misc/coroutines/src/Main.hx
+++ b/tests/misc/coroutines/src/Main.hx
@@ -32,6 +32,7 @@ function main() {
 	runner.addCases("components");
 	runner.addCases("structured");
 	runner.addCases("features");
+	runner.addCases("schedulers");
 
     utest.ui.Report.create(runner);
     runner.run();

--- a/tests/misc/coroutines/src/TestGenerator.hx
+++ b/tests/misc/coroutines/src/TestGenerator.hx
@@ -11,11 +11,11 @@ class ImmediateScheduler extends Scheduler {
 		super();
 	}
 
-	public function schedule(ms:Int64, f:() -> Void) {
+	public function schedule<T>(ms:Int64, state:T, f:(scheduler:Scheduler, state:T) -> Void) {
 		if (ms != 0) {
 			throw 'Only immediate scheduling is allowed in this scheduler';
 		}
-		f();
+		f(this, state);
 		return null;
 	}
 

--- a/tests/misc/coroutines/src/issues/aidan/Issue126.hx
+++ b/tests/misc/coroutines/src/issues/aidan/Issue126.hx
@@ -65,7 +65,7 @@ class Issue126 extends utest.Test {
 		final task = CoroRun.with(scheduler).create(node -> {
 			final channel = new Channel(0);
 			@:coroutine function log(s:String) {
-				channel.write('${scheduler.now()}: $s');
+				channel.write('${@:privateAccess scheduler.now().toString()}: $s');
 			}
 			final junction = new Junction(true);
 			final leftChild = node.async(node -> {

--- a/tests/misc/coroutines/src/issues/aidan/Issue126.hx
+++ b/tests/misc/coroutines/src/issues/aidan/Issue126.hx
@@ -5,6 +5,8 @@ import haxe.coro.schedulers.Scheduler;
 import hxcoro.ds.Channel;
 import hxcoro.ds.PagedDeque;
 
+using hxcoro.util.Convenience;
+
 class Junction {
 	var leftOpen:Bool;
 	var waiters:PagedDeque<SuspendedRead<Any>>;
@@ -17,7 +19,7 @@ class Junction {
 	function flushWaiters() {
 		while (!waiters.isEmpty()) {
 			final cont = waiters.pop();
-			cont.context.get(Scheduler).schedule(0, () -> cont.resume(null, null));
+			cont.context.get(Scheduler).scheduleFunction(() -> cont.resume(null, null));
 		}
 	}
 
@@ -63,7 +65,7 @@ class Issue126 extends utest.Test {
 		final task = CoroRun.with(scheduler).create(node -> {
 			final channel = new Channel(0);
 			@:coroutine function log(s:String) {
-				channel.write('${@:privateAccess scheduler.now().toString()}: $s');
+				channel.write('${scheduler.now()}: $s');
 			}
 			final junction = new Junction(true);
 			final leftChild = node.async(node -> {

--- a/tests/misc/coroutines/src/schedulers/TestVirtualTimeScheduler.hx
+++ b/tests/misc/coroutines/src/schedulers/TestVirtualTimeScheduler.hx
@@ -3,36 +3,38 @@ package schedulers;
 import haxe.coro.schedulers.VirtualTimeScheduler;
 import haxe.exceptions.ArgumentException;
 
+using hxcoro.util.Convenience;
+
 class TestVirtualTimeScheduler extends utest.Test {
 	public function test_time_after_advancing_by() {
 		final sut = new VirtualTimeScheduler();
 
-		Assert.equals(0f64, sut.now());
+		Assert.equals(0i64, sut.now());
 
 		sut.advanceBy(100);
-		Assert.equals(0.1f64, sut.now());
+		Assert.equals(100i64, sut.now());
 
 		sut.advanceBy(400);
-		Assert.equals(0.5f64, sut.now());
+		Assert.equals(500i64, sut.now());
 	}
 
 	public function test_time_after_advancing_to() {
 		final sut = new VirtualTimeScheduler();
 
-		Assert.equals(0f64, sut.now());
+		Assert.equals(0i64, sut.now());
 
 		sut.advanceTo(100);
-		Assert.equals(0.1f64, sut.now());
+		Assert.equals(100i64, sut.now());
 
 		sut.advanceTo(400);
-		Assert.equals(0.4f64, sut.now());
+		Assert.equals(400i64, sut.now());
 	}
 
 	public function test_scheduling_immediate_function() {
 		final result = [];
 		final sut    = new VirtualTimeScheduler();
 
-		sut.schedule(0, () -> result.push(0));
+		sut.scheduleFunction(0, () -> result.push(0));
 		sut.run();
 
 		Assert.same([ 0 ], result);
@@ -42,7 +44,7 @@ class TestVirtualTimeScheduler extends utest.Test {
 		final result = [];
 		final sut    = new VirtualTimeScheduler();
 
-		sut.schedule(10, () -> result.push(0));
+		sut.scheduleFunction(10, () -> result.push(0));
 		sut.advanceBy(10);
 
 		Assert.same([ 0 ], result);
@@ -52,8 +54,8 @@ class TestVirtualTimeScheduler extends utest.Test {
 		final result = [];
 		final sut    = new VirtualTimeScheduler();
 
-		sut.schedule(10, () -> result.push(0));
-		sut.schedule(10, () -> result.push(1));
+		sut.scheduleFunction(10, () -> result.push(0));
+		sut.scheduleFunction(10, () -> result.push(1));
 		sut.advanceBy(10);
 
 		Assert.same([ 0, 1 ], result);
@@ -63,8 +65,8 @@ class TestVirtualTimeScheduler extends utest.Test {
 		final result = [];
 		final sut    = new VirtualTimeScheduler();
 
-		sut.schedule(10, () -> result.push(0));
-		sut.schedule(20, () -> result.push(1));
+		sut.scheduleFunction(10, () -> result.push(0));
+		sut.scheduleFunction(20, () -> result.push(1));
 		sut.advanceBy(20);
 
 		Assert.same([ 0, 1 ], result);
@@ -74,24 +76,25 @@ class TestVirtualTimeScheduler extends utest.Test {
 		final result = [];
 		final sut    = new VirtualTimeScheduler();
 
-		sut.schedule(10, () -> result.push(sut.now()));
-		sut.schedule(20, () -> result.push(sut.now()));
+		sut.scheduleFunction(10, () -> result.push(sut.now()));
+		sut.scheduleFunction(20, () -> result.push(sut.now()));
 		sut.advanceBy(20);
 
-		Assert.same([ 0.01, 0.02 ], result);
+		Assert.isTrue(result[0] == 10i64);
+		Assert.isTrue(result[1] == 20i64);
 	}
 
 	public function test_scheduling_recursive_immediate_functions() {
 		final result = [];
 		final sut    = new VirtualTimeScheduler();
 
-		sut.schedule(0, () -> {
+		sut.scheduleFunction(() -> {
 			result.push(0);
 
-			sut.schedule(0, () -> {
+			sut.scheduleFunction(() -> {
 				result.push(1);
 
-				sut.schedule(0, () -> {
+				sut.scheduleFunction(() -> {
 					result.push(2);
 				});
 				sut.run();
@@ -106,7 +109,7 @@ class TestVirtualTimeScheduler extends utest.Test {
 	public function test_scheduling_negative_time() {
 		final sut = new VirtualTimeScheduler();
 
-		Assert.raises(() -> sut.schedule(-1, () -> {}), ArgumentException);
+		Assert.raises(() -> sut.scheduleFunction(-1, () -> {}), ArgumentException);
 	}
 
 	public function test_advancing_by_negative_time() {
@@ -126,9 +129,9 @@ class TestVirtualTimeScheduler extends utest.Test {
 	public function test_cancelling_scheduled_event() {
 		final result = [];
 		final sut    = new VirtualTimeScheduler();
-		final _      = sut.schedule(10, () -> result.push(0));
-		final handle = sut.schedule(20, () -> result.push(1));
-		final _      = sut.schedule(30, () -> result.push(2));
+		final _      = sut.scheduleFunction(10, () -> result.push(0));
+		final handle = sut.scheduleFunction(20, () -> result.push(1));
+		final _      = sut.scheduleFunction(30, () -> result.push(2));
 
 		handle.close();
 
@@ -140,8 +143,8 @@ class TestVirtualTimeScheduler extends utest.Test {
 	public function test_cancelling_head() {
 		final result = [];
 		final sut    = new VirtualTimeScheduler();
-		final handle = sut.schedule(10, () -> result.push(0));
-		final _      = sut.schedule(20, () -> result.push(1));
+		final handle = sut.scheduleFunction(10, () -> result.push(0));
+		final _      = sut.scheduleFunction(20, () -> result.push(1));
 
 		handle.close();
 
@@ -153,7 +156,7 @@ class TestVirtualTimeScheduler extends utest.Test {
 	public function test_cancelling_single_head() {
 		final result = [];
 		final sut    = new VirtualTimeScheduler();
-		final handle = sut.schedule(10, () -> result.push(0));
+		final handle = sut.scheduleFunction(10, () -> result.push(0));
 
 		handle.close();
 
@@ -165,7 +168,7 @@ class TestVirtualTimeScheduler extends utest.Test {
 	public function test_cancelling_executed_function() {
 		final result = [];
 		final sut    = new VirtualTimeScheduler();
-		final handle = sut.schedule(10, () -> result.push(0));
+		final handle = sut.scheduleFunction(10, () -> result.push(0));
 
 		sut.advanceTo(10);
 

--- a/tests/misc/coroutines/src/structured/TestCancellingSuspend.hx
+++ b/tests/misc/coroutines/src/structured/TestCancellingSuspend.hx
@@ -6,6 +6,8 @@ import haxe.coro.cancellation.CancellationToken;
 import haxe.exceptions.ArgumentException;
 import haxe.exceptions.CancellationException;
 
+using hxcoro.util.Convenience;
+
 class TestCancellingSuspend extends utest.Test {
 	function test_callback() {
 		final actual    = [];
@@ -35,7 +37,7 @@ class TestCancellingSuspend extends utest.Test {
 		final task      = CoroRun.with(scheduler).create(node -> {
 			AssertAsync.raises(() -> {
 				suspendCancellable(cont -> {
-					scheduler.schedule(0, () -> {
+					scheduler.scheduleFunction(() -> {
 						cont.resume(null, null);
 					});
 				});
@@ -56,7 +58,7 @@ class TestCancellingSuspend extends utest.Test {
 		final task      = CoroRun.with(scheduler).create(node -> {
 			AssertAsync.raises(() -> {
 				suspendCancellable(cont -> {
-					scheduler.schedule(0, () -> {
+					scheduler.scheduleFunction(() -> {
 						cont.resume(null, new ArgumentException(''));
 					});
 				});


### PR DESCRIPTION
This adds a state argument to the core scheduling function, as described in #142. I've also added the scheduler argument, while nothing yet uses it, it might be useful. We can always bin it if nothing ends up using it.

I've done a very quick update to get it compiling, some areas could probably use the state argument with some updating.