### PR TITLE
Clean up _hx_tmp handling

### DIFF
--- a/src/coro/coro.ml
+++ b/src/coro/coro.ml
@@ -265,7 +265,7 @@ let create_continuation_class ctx coro_class initial_state =
 
 	ctx.typer.m.curmod.m_types <- ctx.typer.m.curmod.m_types @ [ TClassDecl coro_class.cls ]
 
-let coro_to_state_machine ctx coro_class cb_root exprs args vtmp_result vtmp_error vcompletion vcontinuation stack_item_inserter start_exception =
+let coro_to_state_machine ctx coro_class cb_root exprs args vtmp_result vtmp_error vtmp_error_unwrapped vcompletion vcontinuation stack_item_inserter start_exception =
 	let basic = ctx.typer.t in
 	let b = ctx.builder in
 	let cont = coro_class.ContinuationClassBuilder.continuation_api in
@@ -316,7 +316,7 @@ let coro_to_state_machine ctx coro_class cb_root exprs args vtmp_result vtmp_err
 	let continuation_field cf t =
 		b#instance_field econtinuation coro_class.cls coro_class.outside.param_types cf t
 	in
-	b#void_block [
+	let el = [
 		continuation_var;
 		continuation_assign;
 		b#assign
@@ -324,9 +324,17 @@ let coro_to_state_machine ctx coro_class cb_root exprs args vtmp_result vtmp_err
 			(b#bool true coro_class.name_pos);
 		b#var_init vtmp_result eresult;
 		b#var_init_null vtmp_error;
+	] in
+	let el = if Lazy.is_val vtmp_error_unwrapped then
+		el @ [b#var_init_null (Lazy.force vtmp_error_unwrapped)]
+	else
+		el
+	in
+	let el = el @ [
 		eloop;
 		b#return (b#null basic.tany coro_class.name_pos);
-	]
+	] in
+	b#void_block el
 
 let coro_to_normal ctx coro_class cb_root exprs vcontinuation =
 	let open ContinuationClassBuilder in
@@ -483,8 +491,10 @@ let fun_to_coro ctx coro_type =
 
 	let vtmp_result = alloc_var VGenerated "_hx_result" basic.tany coro_class.name_pos in
 	let etmp_result = b#local vtmp_result coro_class.name_pos in
-	let vtmp_error = alloc_var VGenerated "_hx_error" basic.tany coro_class.name_pos in
+	let vtmp_error = alloc_var VGenerated "_hx_error" basic.texception coro_class.name_pos in
 	let etmp_error = b#local vtmp_error coro_class.name_pos in
+	let vtmp_error_unwrapped = lazy (alloc_var VGenerated "_hx_error_unwrapped" basic.tany coro_class.name_pos) in
+	let etmp_error_unwrapped = lazy (b#local (Lazy.force vtmp_error_unwrapped) coro_class.name_pos) in
 
 	let expr, args, name =
 		match coro_type with
@@ -496,8 +506,8 @@ let fun_to_coro ctx coro_type =
 
 	let cb_root = make_block ctx (Some(expr.etype, coro_class.name_pos)) in
 
-	ignore(CoroFromTexpr.expr_to_coro ctx etmp_result etmp_error cb_root expr);
-	let exprs = {CoroToTexpr.econtinuation;ecompletion;estate;eresult;egoto;eerror;etmp_result;etmp_error} in
+	ignore(CoroFromTexpr.expr_to_coro ctx etmp_result etmp_error_unwrapped cb_root expr);
+	let exprs = {CoroToTexpr.econtinuation;ecompletion;estate;eresult;egoto;eerror;etmp_result;etmp_error;etmp_error_unwrapped} in
 	let stack_item_inserter pos =
 		let field, eargs =
 			match coro_type with
@@ -533,7 +543,7 @@ let fun_to_coro ctx coro_type =
 	in
 	let tf_expr,cb_root = try
 		let cb_root = if ctx.optimize then CoroFromTexpr.optimize_cfg ctx cb_root else cb_root in
-		coro_to_state_machine ctx coro_class cb_root exprs args vtmp_result vtmp_error vcompletion vcontinuation stack_item_inserter start_exception, cb_root
+		coro_to_state_machine ctx coro_class cb_root exprs args vtmp_result vtmp_error vtmp_error_unwrapped vcompletion vcontinuation stack_item_inserter start_exception, cb_root
 	with CoroTco cb_root ->
 		coro_to_normal ctx coro_class cb_root exprs vcontinuation,cb_root
 	in

--- a/src/coro/coro.ml
+++ b/src/coro/coro.ml
@@ -265,7 +265,7 @@ let create_continuation_class ctx coro_class initial_state =
 
 	ctx.typer.m.curmod.m_types <- ctx.typer.m.curmod.m_types @ [ TClassDecl coro_class.cls ]
 
-let coro_to_state_machine ctx coro_class cb_root exprs args vtmp vcompletion vcontinuation stack_item_inserter start_exception =
+let coro_to_state_machine ctx coro_class cb_root exprs args vtmp_result vtmp_error vcompletion vcontinuation stack_item_inserter start_exception =
 	let basic = ctx.typer.t in
 	let b = ctx.builder in
 	let cont = coro_class.ContinuationClassBuilder.continuation_api in
@@ -322,7 +322,8 @@ let coro_to_state_machine ctx coro_class cb_root exprs args vtmp vcompletion vco
 		b#assign
 			(continuation_field cont.recursing basic.tbool)
 			(b#bool true coro_class.name_pos);
-		b#var_init vtmp eresult;
+		b#var_init vtmp_result eresult;
+		b#var_init_null vtmp_error;
 		eloop;
 		b#return (b#null basic.tany coro_class.name_pos);
 	]
@@ -480,8 +481,10 @@ let fun_to_coro ctx coro_type =
 
 	let egoto  = continuation_field cont.goto_label basic.tint in
 
-	let vtmp = alloc_var VGenerated "_hx_tmp" basic.tany coro_class.name_pos in
-	let etmp = b#local vtmp coro_class.name_pos in
+	let vtmp_result = alloc_var VGenerated "_hx_result" basic.tany coro_class.name_pos in
+	let etmp_result = b#local vtmp_result coro_class.name_pos in
+	let vtmp_error = alloc_var VGenerated "_hx_error" basic.tany coro_class.name_pos in
+	let etmp_error = b#local vtmp_error coro_class.name_pos in
 
 	let expr, args, name =
 		match coro_type with
@@ -493,8 +496,8 @@ let fun_to_coro ctx coro_type =
 
 	let cb_root = make_block ctx (Some(expr.etype, coro_class.name_pos)) in
 
-	ignore(CoroFromTexpr.expr_to_coro ctx etmp cb_root expr);
-	let exprs = {CoroToTexpr.econtinuation;ecompletion;estate;eresult;egoto;eerror;etmp} in
+	ignore(CoroFromTexpr.expr_to_coro ctx etmp_result etmp_error cb_root expr);
+	let exprs = {CoroToTexpr.econtinuation;ecompletion;estate;eresult;egoto;eerror;etmp_result;etmp_error} in
 	let stack_item_inserter pos =
 		let field, eargs =
 			match coro_type with
@@ -530,7 +533,7 @@ let fun_to_coro ctx coro_type =
 	in
 	let tf_expr,cb_root = try
 		let cb_root = if ctx.optimize then CoroFromTexpr.optimize_cfg ctx cb_root else cb_root in
-		coro_to_state_machine ctx coro_class cb_root exprs args vtmp vcompletion vcontinuation stack_item_inserter start_exception, cb_root
+		coro_to_state_machine ctx coro_class cb_root exprs args vtmp_result vtmp_error vcompletion vcontinuation stack_item_inserter start_exception, cb_root
 	with CoroTco cb_root ->
 		coro_to_normal ctx coro_class cb_root exprs vcontinuation,cb_root
 	in

--- a/src/coro/coroFromTexpr.ml
+++ b/src/coro/coroFromTexpr.ml
@@ -12,7 +12,7 @@ type coro_ret =
 	| RBlock
 	| RMapExpr of coro_ret * (texpr -> texpr)
 
-let expr_to_coro ctx etmp cb_root e =
+let expr_to_coro ctx etmp_result etmp_error cb_root e =
 	let make_block typepos =
 		make_block ctx typepos
 	in
@@ -182,7 +182,7 @@ let expr_to_coro ctx etmp cb_root e =
 								cb_next.cb_stack_value <- Some ev;
 								ev
 							| _ ->
-								etmp
+								etmp_result
 							in
 							let suspend = {
 								cs_fun = e1;
@@ -319,7 +319,7 @@ let expr_to_coro ctx etmp cb_root e =
 			let cb_next = lazy (make_block None) in
 			let catches = List.map (fun (v,e) ->
 				let cb_catch = block_from_e e in
-				add_expr cb_catch (mk (TVar(v,Some etmp)) ctx.typer.t.tvoid null_pos);
+				add_expr cb_catch (mk (TVar(v,Some etmp_error)) ctx.typer.t.tvoid null_pos);
 				let cb_catch_next = loop_block cb_catch ret e in
 				Option.may (fun (cb_catch_next,_) ->
 					fall_through cb_catch_next (Lazy.force cb_next);

--- a/src/coro/coroFromTexpr.ml
+++ b/src/coro/coroFromTexpr.ml
@@ -12,7 +12,7 @@ type coro_ret =
 	| RBlock
 	| RMapExpr of coro_ret * (texpr -> texpr)
 
-let expr_to_coro ctx etmp_result etmp_error cb_root e =
+let expr_to_coro ctx etmp_result etmp_error_unwrapped cb_root e =
 	let make_block typepos =
 		make_block ctx typepos
 	in
@@ -319,7 +319,7 @@ let expr_to_coro ctx etmp_result etmp_error cb_root e =
 			let cb_next = lazy (make_block None) in
 			let catches = List.map (fun (v,e) ->
 				let cb_catch = block_from_e e in
-				add_expr cb_catch (mk (TVar(v,Some etmp_error)) ctx.typer.t.tvoid null_pos);
+				add_expr cb_catch (mk (TVar(v,Some (Lazy.force etmp_error_unwrapped))) ctx.typer.t.tvoid null_pos);
 				let cb_catch_next = loop_block cb_catch ret e in
 				Option.may (fun (cb_catch_next,_) ->
 					fall_through cb_catch_next (Lazy.force cb_next);

--- a/src/coro/coroToTexpr.ml
+++ b/src/coro/coroToTexpr.ml
@@ -17,7 +17,8 @@ type coro_to_texpr_exprs = {
 	eresult : texpr;
 	egoto : texpr;
 	eerror : texpr;
-	etmp : texpr;
+	etmp_result : texpr;
+	etmp_error : texpr;
 }
 
 let make_suspending_call basic call econtinuation =
@@ -144,7 +145,7 @@ let handle_locals ctx b cls states tf_args forbidden_vars econtinuation =
 	fields
 
 let block_to_texpr_coroutine ctx cb cont cls params tf_args forbidden_vars exprs p stack_item_inserter start_exception =
-	let {econtinuation;ecompletion;estate;eresult;egoto;eerror;etmp} = exprs in
+	let {econtinuation;ecompletion;estate;eresult;egoto;eerror;etmp_result;etmp_error} = exprs in
 	let com = ctx.typer.com in
 	let b = ctx.builder in
 
@@ -177,14 +178,14 @@ let block_to_texpr_coroutine ctx cb cont cls params tf_args forbidden_vars exprs
 		] in
 		let ereturned = b#assign call.cs_result (base_continuation_field_on ecororesult cont.result com.basic.tany) in
 		(* TODO: all this is very awkward *)
-		let ereturned = if call.cs_result == etmp then
+		let ereturned = if call.cs_result == etmp_result then
 			ereturned
 		else
-			b#assign etmp ereturned
+			b#assign etmp_result ereturned
 		in
 		let eerror = base_continuation_field_on ecororesult cont.error cont.error.cf_type in
 		let ethrown = b#void_block [
-			b#assign etmp eerror;
+			b#assign etmp_error eerror;
 			b#break p;
 		] in
 		let estate_switch = CoroControl.make_control_switch com.basic esubject esuspended ereturned ethrown p in
@@ -214,7 +215,7 @@ let block_to_texpr_coroutine ctx cb cont cls params tf_args forbidden_vars exprs
 	in
 	let eif_error cb =
 		let el = [
-			b#assign etmp eerror;
+			b#assign etmp_error eerror;
 			b#break p;
 		] in
 		let e_then = b#void_block el in
@@ -223,7 +224,7 @@ let block_to_texpr_coroutine ctx cb cont cls params tf_args forbidden_vars exprs
 			| None ->
 				b#if_then e_if e_then
 			| Some e ->
-				let e_assign = b#assign e etmp in
+				let e_assign = b#assign e etmp_result in
 				b#if_then_else e_if e_then e_assign com.basic.tvoid
 	in
 
@@ -268,7 +269,7 @@ let block_to_texpr_coroutine ctx cb cont cls params tf_args forbidden_vars exprs
 		| NextReturn e ->
 			add_state (Some (-1)) [ set_control CoroReturned; b#assign eresult e; ereturn ]
 		| NextThrow e1 ->
-			add_state None ([b#assign etmp e1; stack_item_inserter e1.epos; start_exception (wrap_thrown etmp); b#break p ])
+			add_state None ([b#assign etmp_error e1; stack_item_inserter e1.epos; start_exception (wrap_thrown etmp_error); b#break p ])
 		| NextSub (cb_sub,cb_next) ->
 			add_state (Some cb_sub.cb_id) []
 
@@ -315,7 +316,7 @@ let block_to_texpr_coroutine ctx cb cont cls params tf_args forbidden_vars exprs
 					| TDynamic _ ->
 						set_state cb_catch.cb_id (* no next *)
 					| t ->
-						let etypecheck = std_is etmp vcatch.v_type in
+						let etypecheck = std_is etmp_error vcatch.v_type in
 						b#if_then_else etypecheck (set_state cb_catch.cb_id) enext com.basic.tvoid
 				) erethrow (List.rev catch.cc_catches)
 			in
@@ -337,7 +338,7 @@ let block_to_texpr_coroutine ctx cb cont cls params tf_args forbidden_vars exprs
 	let fields = handle_locals ctx b cls states tf_args forbidden_vars econtinuation in
 
 	let ethrow = b#void_block [
-		b#assign etmp (b#string "Invalid coroutine state" p);
+		b#assign etmp_error (b#string "Invalid coroutine state" p);
 		b#break p
 	] in
 
@@ -362,7 +363,7 @@ let block_to_texpr_coroutine ctx cb cont cls params tf_args forbidden_vars exprs
 				let ecaught = b#local vcaught p in
 				let e = b#void_block [
 					start_exception (wrap_thrown ecaught);
-					b#assign etmp ecaught
+					b#assign etmp_error ecaught
 				] in
 				(vcaught,e)
 			]
@@ -386,7 +387,7 @@ let block_to_texpr_coroutine ctx cb cont cls params tf_args forbidden_vars exprs
 			let eaccess       = b#instance_field econtinuation com.basic.tcoro.base_continuation_class params field field.cf_type in
 			let ewrapped_call = mk (TCall (eaccess, [ ])) com.basic.tvoid p in
 			[
-				b#assign eerror (wrap_thrown etmp);
+				b#assign eerror (wrap_thrown etmp_error);
 				ewrapped_call;
 				set_control CoroThrown;
 				ereturn;

--- a/src/coro/coroToTexpr.ml
+++ b/src/coro/coroToTexpr.ml
@@ -19,6 +19,7 @@ type coro_to_texpr_exprs = {
 	eerror : texpr;
 	etmp_result : texpr;
 	etmp_error : texpr;
+	etmp_error_unwrapped : texpr Lazy.t;
 }
 
 let make_suspending_call basic call econtinuation =
@@ -145,7 +146,7 @@ let handle_locals ctx b cls states tf_args forbidden_vars econtinuation =
 	fields
 
 let block_to_texpr_coroutine ctx cb cont cls params tf_args forbidden_vars exprs p stack_item_inserter start_exception =
-	let {econtinuation;ecompletion;estate;eresult;egoto;eerror;etmp_result;etmp_error} = exprs in
+	let {econtinuation;ecompletion;estate;eresult;egoto;eerror;etmp_result;etmp_error;etmp_error_unwrapped} = exprs in
 	let com = ctx.typer.com in
 	let b = ctx.builder in
 
@@ -205,11 +206,17 @@ let block_to_texpr_coroutine ctx cb cont cls params tf_args forbidden_vars exprs
 		cs_el = el;
 	} in
 
-	(* TODO: this sucks a bit and its usage isn't much better *)
-	let wrap_thrown,get_caught = match com.basic.texception with
+	let get_caught,unwrap_exception = match com.basic.texception with
 		| TInst(c,_) ->
-			(fun e -> Texpr.Builder.resolve_and_make_static_call c "thrown" [e] e.epos),
-			(fun e -> Texpr.Builder.resolve_and_make_static_call c "caught" [e] e.epos)
+			let unwrap =
+				let cf = PMap.find "unwrap" c.cl_fields in
+				(fun e ->
+					let e = b#instance_field e c [] cf cf.cf_type in
+					b#call e [] com.basic.tany
+				)
+			in
+			(fun e -> Texpr.Builder.resolve_and_make_static_call c "caught" [e] e.epos),
+			unwrap
 		| _ ->
 			die "" __LOC__
 	in
@@ -269,7 +276,7 @@ let block_to_texpr_coroutine ctx cb cont cls params tf_args forbidden_vars exprs
 		| NextReturn e ->
 			add_state (Some (-1)) [ set_control CoroReturned; b#assign eresult e; ereturn ]
 		| NextThrow e1 ->
-			add_state None ([b#assign etmp_error e1; stack_item_inserter e1.epos; start_exception (wrap_thrown etmp_error); b#break p ])
+			add_state None ([b#assign etmp_error (get_caught e1); stack_item_inserter e1.epos; start_exception etmp_error; b#break p ])
 		| NextSub (cb_sub,cb_next) ->
 			add_state (Some cb_sub.cb_id) []
 
@@ -316,11 +323,16 @@ let block_to_texpr_coroutine ctx cb cont cls params tf_args forbidden_vars exprs
 					| TDynamic _ ->
 						set_state cb_catch.cb_id (* no next *)
 					| t ->
-						let etypecheck = std_is etmp_error vcatch.v_type in
+						let etypecheck = std_is (Lazy.force etmp_error_unwrapped) vcatch.v_type in
 						b#if_then_else etypecheck (set_state cb_catch.cb_id) enext com.basic.tvoid
 				) erethrow (List.rev catch.cc_catches)
 			in
-			states := (make_state new_exc_state_id [eif]) :: !states;
+			let el = if Lazy.is_val etmp_error_unwrapped then
+				[b#assign (Lazy.force etmp_error_unwrapped) (unwrap_exception etmp_error);eif]
+			else
+				[eif]
+			in
+			states := (make_state new_exc_state_id el) :: !states;
 			add_state (Some cb_try.cb_id) []
 	in
 	let rec loop cb =
@@ -338,7 +350,7 @@ let block_to_texpr_coroutine ctx cb cont cls params tf_args forbidden_vars exprs
 	let fields = handle_locals ctx b cls states tf_args forbidden_vars econtinuation in
 
 	let ethrow = b#void_block [
-		b#assign etmp_error (b#string "Invalid coroutine state" p);
+		b#assign etmp_error (get_caught (b#string "Invalid coroutine state" p));
 		b#break p
 	] in
 
@@ -361,8 +373,9 @@ let block_to_texpr_coroutine ctx cb cont cls params tf_args forbidden_vars exprs
 			[
 				let vcaught = alloc_var VGenerated "e" t_dynamic p in
 				let ecaught = b#local vcaught p in
+				let ecaught = get_caught ecaught in
 				let e = b#void_block [
-					start_exception (wrap_thrown ecaught);
+					start_exception ecaught;
 					b#assign etmp_error ecaught
 				] in
 				(vcaught,e)
@@ -387,7 +400,7 @@ let block_to_texpr_coroutine ctx cb cont cls params tf_args forbidden_vars exprs
 			let eaccess       = b#instance_field econtinuation com.basic.tcoro.base_continuation_class params field field.cf_type in
 			let ewrapped_call = mk (TCall (eaccess, [ ])) com.basic.tvoid p in
 			[
-				b#assign eerror (wrap_thrown etmp_error);
+				b#assign eerror etmp_error;
 				ewrapped_call;
 				set_control CoroThrown;
 				ereturn;

--- a/tests/misc/coroutines/src/AssertAsync.hx
+++ b/tests/misc/coroutines/src/AssertAsync.hx
@@ -9,7 +9,7 @@ class AssertAsync {
 
 		try {
 			method();
-		} catch (ex) {
+		} catch (ex:Dynamic) {
 			var ex = Std.isOfType(ex, ValueException) ? (cast ex:ValueException).value : (ex:Any);
 
 			return Assert.isTrue(Std.isOfType(ex, type), "expected " + typeDescr + " but it is "  + ex);

--- a/tests/misc/coroutines/src/issues/aidan/Issue145.hx
+++ b/tests/misc/coroutines/src/issues/aidan/Issue145.hx
@@ -1,0 +1,32 @@
+package issues.aidan;
+
+@:coroutine function throwing() {
+	throw "throwing";
+}
+
+@:coroutine function throwingAfterYield() {
+	yield();
+	throw "throwing";
+}
+
+class Issue145 extends utest.Test {
+	function testSurprisinglySimple1() {
+		final result = CoroRun.run(() -> try {
+			throwing();
+			"oh no";
+		} catch(s:String) {
+			s;
+		});
+		Assert.equals("throwing", result);
+
+	}
+	function testSurprisinglySimple2() {
+		final result = CoroRun.run(() -> try {
+			throwingAfterYield();
+			"oh no";
+		} catch (s:String) {
+			s;
+		});
+		Assert.equals("throwing", result);
+	}
+}


### PR DESCRIPTION
Some internal cleanup related to `_hx_tmp`, which has now been split up:

* `_hx_result:Any` for (intermediate) result values
* `_hx_error:Exception` for (intermediate) exceptions
* `_hx_error_unwrapped:Any` for the actual value of an exception that is checked in `catch` blocks

This lead to some cleanup related to the wrapping and unwrapping of exceptions, which works a little better now. #139 hinted at something being wrong after all because that is no longer an issue now.

I'll also add some surprisingly simple tests that fail on kt_coro.