### PR TITLE
[tests] fix server tests

### DIFF
--- a/tests/RunCi.hx
+++ b/tests/RunCi.hx
@@ -37,7 +37,7 @@ class RunCi {
 			infoMsg('test $test');
 			try {
 				changeDirectory(unitDir);
-				haxelibInstallGit("haxe-utest", "utest", "424a7182a93057730fada54b9d27d90b3cb7065c", "--always");
+				haxelibInstallGit("kLabz", "utest", "coro", "--always");
 
 				var args = switch (ci) {
 					case null:

--- a/tests/RunCi.hx
+++ b/tests/RunCi.hx
@@ -37,7 +37,7 @@ class RunCi {
 			infoMsg('test $test');
 			try {
 				changeDirectory(unitDir);
-				haxelibInstallGit("kLabz", "utest", "coro", "--always");
+				haxelibInstallGit("aidan63", "utest", "coro", "--always");
 
 				var args = switch (ci) {
 					case null:

--- a/tests/runci/targets/Js.hx
+++ b/tests/runci/targets/Js.hx
@@ -125,13 +125,13 @@ class Js {
 
 		runci.targets.Jvm.getJavaDependencies(); // this is awkward
 		haxelibInstallGit("Simn", "haxeserver");
-		// changeDirectory(serverDir);
-		// runCommand("haxe", ["build.hxml"]);
-		// runCommand("node", ["test.js"]);
-		// runCommand("haxe", ["build.hxml", "-D", "disable-hxb-optimizations"]);
-		// runCommand("node", ["test.js"]);
-		// runCommand("haxe", ["build.hxml", "-D", "disable-hxb-cache"]);
-		// runCommand("node", ["test.js"]);
+		changeDirectory(serverDir);
+		runCommand("haxe", ["build.hxml"]);
+		runCommand("node", ["test.js"]);
+		runCommand("haxe", ["build.hxml", "-D", "disable-hxb-optimizations"]);
+		runCommand("node", ["test.js"]);
+		runCommand("haxe", ["build.hxml", "-D", "disable-hxb-cache"]);
+		runCommand("node", ["test.js"]);
 
 		Display.maybeRunDisplayTests(Js);
 

--- a/tests/server/src/TestCase.hx
+++ b/tests/server/src/TestCase.hx
@@ -77,10 +77,14 @@ class TestCase implements ITest implements ITestCase {
 	public function setup(async:utest.Async) {
 		testDir = "test/cases/" + i++;
 		vfs = new Vfs(testDir);
-		hxcoro.CoroRun.run(() -> {
-			runHaxeJson(["--cwd", rootCwd, "--cwd", testDir], Methods.ResetCache, {});
-			async.done();
-		});
+
+		utest
+			.CoroutineHelpers
+			.promise(() -> {
+				runHaxeJson(["--cwd", rootCwd, "--cwd", testDir], Methods.ResetCache, {});
+
+				async.done();
+			});
 	}
 
 	public function teardown() {}

--- a/tests/server/src/TestCase.hx
+++ b/tests/server/src/TestCase.hx
@@ -77,7 +77,8 @@ class TestCase implements ITest implements ITestCase {
 	public function setup(async:utest.Async) {
 		testDir = "test/cases/" + i++;
 		vfs = new Vfs(testDir);
-		runHaxeJson(["--cwd", rootCwd, "--cwd", testDir], Methods.ResetCache, {}, () -> {
+		hxcoro.CoroRun.run(() -> {
+			runHaxeJson(["--cwd", rootCwd, "--cwd", testDir], Methods.ResetCache, {});
 			async.done();
 		});
 	}
@@ -99,43 +100,55 @@ class TestCase implements ITest implements ITestCase {
 		}
 	}
 
-	function runHaxe(args:Array<String>, done:() -> Void) {
+	@:coroutine
+	function runHaxe(args:Array<String>) {
 		messages = [];
 		errorMessages = [];
-		server.rawRequest(args, null, function(result) {
-			handleResult(result);
-			if (result.hasError) {
-				sendErrorMessage(result.stderr);
-			}
-			done();
-		}, sendErrorMessage);
+
+		hxcoro.Coro.suspend(cont -> {
+			server.rawRequest(args, null, function(result) {
+				handleResult(result);
+				if (result.hasError) {
+					sendErrorMessage(result.stderr);
+				}
+				cont.resume(null, null);
+			}, err -> {
+				sendErrorMessage(err);
+				cont.resume(null, null);
+			});
+		});
 	}
 
-	function runHaxeJson<TParams, TResponse>(args:Array<String>, method:HaxeRequestMethod<TParams, TResponse>, methodArgs:TParams, done:() -> Void) {
+	@:coroutine
+	function runHaxeJson<TParams, TResponse>(args:Array<String>, method:HaxeRequestMethod<TParams, TResponse>, methodArgs:TParams) {
 		var methodArgs = {method: method, id: 1, params: methodArgs};
 		args = args.concat(['--display', Json.stringify(methodArgs)]);
-		runHaxe(args, done);
+		runHaxe(args);
 	}
 
+	@:coroutine
 	function runHaxeJsonCb<TParams, TResponse>(args:Array<String>, method:HaxeRequestMethod<TParams, Response<TResponse>>, methodArgs:TParams,
-			callback:TResponse->Void, done:() -> Void, ?pos:PosInfos) {
+			callback:TResponse->Void, ?pos:PosInfos) {
 		var methodArgs = {method: method, id: 1, params: methodArgs};
 		args = args.concat(['--display', Json.stringify(methodArgs)]);
 		messages = [];
 		errorMessages = [];
-		server.rawRequest(args, null, function(result) {
-			handleResult(result);
-			var json = try Json.parse(result.stderr) catch(e) {result: null, error: e.message + " (Response: " + result.stderr + ")"};
 
-			if (json.result != null) {
-				callback(json.result?.result);
-			} else {
-				Assert.fail('Error: ' + json.error, pos);
-			}
-			done();
-		}, function(msg) {
-			sendErrorMessage(msg);
-			done();
+		hxcoro.Coro.suspend(cont -> {
+			server.rawRequest(args, null, function(result) {
+				handleResult(result);
+				var json = try Json.parse(result.stderr) catch(e) {result: null, error: e.message + " (Response: " + result.stderr + ")"};
+
+				if (json.result != null) {
+					callback(json.result?.result);
+				} else {
+					Assert.fail('Error: ' + json.error, pos);
+				}
+				cont.resume(null, null);
+			}, function(msg) {
+				sendErrorMessage(msg);
+				cont.resume(null, null);
+			});
 		});
 	}
 

--- a/tests/server/src/cases/CsSafeTypeBuilding.hx
+++ b/tests/server/src/cases/CsSafeTypeBuilding.hx
@@ -25,7 +25,8 @@ class CsSafeTypeBuilding extends TestCase {
 		vfs.putContent("Macro.macro.hx", getTemplate("csSafeTypeBuilding/Macro.macro.hx"));
 		vfs.putContent("Main.hx", getTemplate("csSafeTypeBuilding/Main.hx"));
 
-		runHaxeJson(["--cwd", TestCase.rootCwd, "--cwd", testDir], Methods.ResetCache, {}, () -> {
+		hxcoro.CoroRun.run(() -> {
+			runHaxeJson(["--cwd", TestCase.rootCwd, "--cwd", testDir], Methods.ResetCache, {});
 			async.done();
 		});
 	}

--- a/tests/server/src/cases/CsSafeTypeBuilding.hx
+++ b/tests/server/src/cases/CsSafeTypeBuilding.hx
@@ -25,10 +25,13 @@ class CsSafeTypeBuilding extends TestCase {
 		vfs.putContent("Macro.macro.hx", getTemplate("csSafeTypeBuilding/Macro.macro.hx"));
 		vfs.putContent("Main.hx", getTemplate("csSafeTypeBuilding/Main.hx"));
 
-		hxcoro.CoroRun.run(() -> {
-			runHaxeJson(["--cwd", TestCase.rootCwd, "--cwd", testDir], Methods.ResetCache, {});
-			async.done();
-		});
+		utest
+			.CoroutineHelpers
+			.promise(() -> {
+				runHaxeJson(["--cwd", TestCase.rootCwd, "--cwd", testDir], Methods.ResetCache, {});
+				
+				async.done();
+			});
 	}
 
 	#if debug

--- a/tests/server/src/cases/issues/Issue12001.hx
+++ b/tests/server/src/cases/issues/Issue12001.hx
@@ -30,6 +30,7 @@ class Issue12001 extends TestCase {
 
 	@:async
 	@:timeout(3000)
+	@:coroutine
 	function testRedefineType(async:Async) {
 		vfs.putContent("Macro.hx", getTemplate("issues/Issue12001/Macro.hx"));
 		vfs.putContent("Main.hx", getTemplate("issues/Issue12001/Main.hx"));
@@ -45,7 +46,8 @@ class Issue12001 extends TestCase {
 			if (++i >= 5) async.done();
 			else test();
 		}
-		hxcoro.CoroRun.run(test);
+		
+		test();
 	}
 
 	function testDefineModule(_) {
@@ -75,6 +77,7 @@ class Issue12001 extends TestCase {
 
 	@:async
 	@:timeout(3000)
+	@:coroutine
 	function testRedefineModule(async:Async) {
 		vfs.putContent("Macro.hx", getTemplate("issues/Issue12001/Macro.hx"));
 		vfs.putContent("Main.hx", getTemplate("issues/Issue12001/Main1.hx"));
@@ -90,11 +93,13 @@ class Issue12001 extends TestCase {
 			if (++i >= 5) async.done();
 			else test();
 		}
-		hxcoro.CoroRun.run(test);
+		
+		test();
 	}
 
 	@:async
 	@:timeout(3000)
+	@:coroutine
 	function testRedefineAfterTyping(async:Async) {
 		vfs.putContent("Macro.hx", getTemplate("issues/Issue12001/Macro.hx"));
 		vfs.putContent("Empty.hx", getTemplate("Empty.hx"));
@@ -110,7 +115,8 @@ class Issue12001 extends TestCase {
 			if (++i >= 5) async.done();
 			else test();
 		}
-		hxcoro.CoroRun.run(test);
+		
+		test();
 	}
 
 	function testInvalidateError(_) {

--- a/tests/server/src/cases/issues/Issue12001.hx
+++ b/tests/server/src/cases/issues/Issue12001.hx
@@ -35,16 +35,17 @@ class Issue12001 extends TestCase {
 		vfs.putContent("Main.hx", getTemplate("issues/Issue12001/Main.hx"));
 		var args = ["-main", "Main", "--interp", "--macro", "Macro.defineType()"];
 		var i = 0;
+
+		@:coroutine
 		function test() {
 			// Was failing with nightlies (HxbFailure)
-			runHaxe(args, () -> {
-				assertSuccess();
-				assertHasPrint("Foo.test() = " + i);
-				if (++i >= 5) async.done();
-				else test();
-			});
+			runHaxe(args);
+			assertSuccess();
+			assertHasPrint("Foo.test() = " + i);
+			if (++i >= 5) async.done();
+			else test();
 		}
-		test();
+		hxcoro.CoroRun.run(test);
 	}
 
 	function testDefineModule(_) {
@@ -79,16 +80,17 @@ class Issue12001 extends TestCase {
 		vfs.putContent("Main.hx", getTemplate("issues/Issue12001/Main1.hx"));
 		var args = ["-main", "Main", "--interp", "--macro", "Macro.defineModule()"];
 		var i = 0;
+
+		@:coroutine
 		function test() {
 			// Was failing with nightlies (HxbFailure)
-			runHaxe(args, () -> {
-				assertSuccess();
-				assertHasPrint("Bar.test() = " + i);
-				if (++i >= 5) async.done();
-				else test();
-			});
+			runHaxe(args);
+			assertSuccess();
+			assertHasPrint("Bar.test() = " + i);
+			if (++i >= 5) async.done();
+			else test();
 		}
-		test();
+		hxcoro.CoroRun.run(test);
 	}
 
 	@:async
@@ -98,16 +100,17 @@ class Issue12001 extends TestCase {
 		vfs.putContent("Empty.hx", getTemplate("Empty.hx"));
 		var args = ["-main", "Empty", "--interp", "--macro", "Macro.hookRedefine()"];
 		var i = 0;
+
+		@:coroutine
 		function test() {
-			runHaxe(args, () -> {
-				assertSuccess();
-				// Newest version is being included
-				assertHasPrint("Baz.test() = " + i);
-				if (++i >= 5) async.done();
-				else test();
-			});
+			runHaxe(args);
+			assertSuccess();
+			// Newest version is being included
+			assertHasPrint("Baz.test() = " + i);
+			if (++i >= 5) async.done();
+			else test();
 		}
-		test();
+		hxcoro.CoroRun.run(test);
 	}
 
 	function testInvalidateError(_) {

--- a/tests/server/src/utils/macro/DisplayTestBuilder.macro.hx
+++ b/tests/server/src/utils/macro/DisplayTestBuilder.macro.hx
@@ -15,7 +15,7 @@ private class BuilderException extends Exception {
 class DisplayTestBuilder {
 	static public function build(fields:Array<Field>):Array<Field> {
 		for (field in fields) {
-			if (field.name.startsWith('test')) {
+			if (field.name.startsWith('test') && field.doc != null) {
 				try {
 					patchExpr(field);
 				} catch (e) {

--- a/tests/server/src/utils/macro/TestBuilder.macro.hx
+++ b/tests/server/src/utils/macro/TestBuilder.macro.hx
@@ -27,7 +27,6 @@ class TestBuilder {
 						// TODO: support functions that define their own async arg (not named `_` or `async`)
 						var args = f.args.copy();
 						f.args = [];
-						makeAsyncTest(field);
 
 						// Ignore original field; generate variants instead
 						removedFields.push(field);
@@ -67,14 +66,16 @@ class TestBuilder {
 										args: [{name: "async", type: macro:utest.Async}]
 									};
 
-									newFields.push({
+									var f = {
 										pos: variant.pos,
 										name: field.name + name,
 										meta: field.meta.filter(m -> m.name != ":variant"),
 										kind: FFun(ff),
 										doc: field.doc,
 										access : field.access
-									});
+									};
+									makeAsyncTest(f);
+									newFields.push(f);
 
 								case _:
 							}


### PR DESCRIPTION
~~The fix in https://github.com/Aidan63/haxe/pull/164/commits/968fb46a339add495e055d06488f831053b10a72 should not be needed, but atm if a coro function body starts with an empty block `{}` then the rest of the body is skipped somehow~~ fixed in https://github.com/Aidan63/haxe/commit/ccfb3730917d82523ed542ad26ddd5b8ed6af80d