### PR TITLE
Move continuations to be the leading argument

### DIFF
--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -1152,7 +1152,7 @@ let get_entry_point com =
 	) com.main.main_path
 
 let expand_coro_type basic args ret =
-	let args = args @ [("_hx_continuation",false,Lazy.force basic.tcoro.continuation)] in
+	let args = ("_hx_continuation",false,Lazy.force basic.tcoro.continuation) :: args in
 	let ret = if ExtType.is_void (follow ret) then basic.tunit else ret in
 	let c = Lazy.force basic.tcoro.suspension_result_class in
 	(args,TInst(c,[ret]))

--- a/src/coro/coro.ml
+++ b/src/coro/coro.ml
@@ -204,19 +204,19 @@ module ContinuationClassBuilder = struct
 			in
 			match coro_class.coro_type with
 			| ClassField (cls, field, f, _) when has_class_field_flag field CfStatic ->
-				let args      = (f.tf_args |> map_args) @ [ ethis ] in
+				let args      = ethis :: (f.tf_args |> map_args) in
 				let estaticthis = Builder.make_static_this cls coro_class.name_pos in
 				let tcf = substitute_type_params coro_class.type_param_subst field.cf_type in
 				let efunction = b#static_field estaticthis cls field tcf in
 				b#call efunction args tret_invoke_resume
 			| ClassField (cls, field,f, _) ->
-				let args      = (f.tf_args |> map_args) @ [ ethis ] in
+				let args      = ethis :: (f.tf_args |> map_args) in
 				let captured  = coro_class.captured |> Option.get in
 				let ecapturedfield = this_field captured in
 				let efunction      = b#instance_field ecapturedfield cls [] (* TODO: check *) field field.cf_type in
 				b#call efunction args tret_invoke_resume
 			| LocalFunc(f,_) ->
-				let args      = (f.tf_args |> map_args) @ [ ethis ] in
+				let args      = ethis :: (f.tf_args |> map_args) in
 				let captured  = coro_class.captured |> Option.get in
 				let ecapturedfield = this_field captured in
 				b#call ecapturedfield args tret_invoke_resume
@@ -530,7 +530,7 @@ let fun_to_coro ctx coro_type =
 		coro_to_normal ctx cont coro_class cb_root exprs vcontinuation,cb_root
 	in
 
-	let tf_args = args @ [ (vcompletion,None) ] in
+	let tf_args = (vcompletion,None) :: args in
 	(* I'm not sure what this should be, but let's stick to the widest one for now.
 	   Cpp dies if I try to use coro_class.outside.cls_t here, which might be something
 	   to investigate independently. *)

--- a/src/coro/coroToTexpr.ml
+++ b/src/coro/coroToTexpr.ml
@@ -43,7 +43,7 @@ let make_suspending_call basic cont call econtinuation =
 			die "Unexpected coroutine type" __LOC__
 	in
 	let efun = { call.cs_fun with etype = tfun } in
-	let args = call.cs_args @ [ econtinuation ] in
+	let args = econtinuation :: call.cs_args in
 	mk (TCall (efun, args)) (cont.suspension_result basic.tany) call.cs_pos
 
 let handle_locals ctx b cls states tf_args forbidden_vars econtinuation =

--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -1265,9 +1265,9 @@ let create_method (ctx,cctx,fctx) c f cf fd p =
 	let t = if not is_coroutine then
 		TFun (targs,ret)
 	else if Meta.has Meta.CoroutineTransformed cf.cf_meta then begin
-		match List.rev targs with
+		match targs with
 			| _ :: targs ->
-				(* Ignore trailing continuation for actual signature *)
+				(* Ignore leading continuation for actual signature *)
 				(Lazy.force ctx.t.tcoro.tcoro) (List.rev targs) ret
 			| _ ->
 				die "" __LOC__

--- a/tests/runci/targets/Js.hx
+++ b/tests/runci/targets/Js.hx
@@ -123,7 +123,7 @@ class Js {
 
 		runci.targets.Jvm.getJavaDependencies(); // this is awkward
 		haxelibInstallGit("Simn", "haxeserver");
-		haxelibInstallGit("HaxeFoundation", "hxcoro");
+		haxelibInstallGit("HaxeFoundation", "hxcoro", "leading-completion");
 		changeDirectory(serverDir);
 		runCommand("haxe", ["build.hxml"]);
 		runCommand("node", ["test.js"]);

--- a/tests/runci/targets/Macro.hx
+++ b/tests/runci/targets/Macro.hx
@@ -61,7 +61,7 @@ class Macro {
 		runCommand("haxe", ["tests.hxml", "-w", "-WDeprecated", "--interp", "--macro", "addMetadata('@:exclude','Futures','testDelay')"]);
 
 		changeDirectory(partyDir);
-		runCommand("git", ["clone", "https://github.com/HaxeFoundation/hxcoro", "hxcoro"]);
+		runCommand("git", ["clone", "-b", "leading-completion", "https://github.com/HaxeFoundation/hxcoro", "hxcoro" ]);
 		changeDirectory("hxcoro");
 		runCommand("haxelib", ["newrepo"]);
 		runCommand("haxelib", ["git", "utest", "https://github.com/Aidan63/utest.git", "coro"]);


### PR DESCRIPTION
This gets js, php, and python passing the optional argument tests I added to hxcoro. Jvm still complains though, this time with a "NoSuchMethodException" which I'm still tracking down.

<img width="1093" height="357" alt="image" src="https://github.com/user-attachments/assets/68a46448-50f0-494b-ab94-ba3494612c4b" />
